### PR TITLE
Added the option to install Oxide/uMod and plugins

### DIFF
--- a/hurtworld/egg-hurtworld.json
+++ b/hurtworld/egg-hurtworld.json
@@ -4,10 +4,10 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-10-07T22:46:51+08:00",
+    "exported_at": "2025-02-12T15:57:31+01:00",
     "name": "Hurtworld",
     "author": "brycea@terrahost.cloud",
-    "description": "Hurtworld is a hardcore multiplayer survival FPS with a focus on deep survival progression that doesn't become trivial once you establish some basic needs. Built for hardcore gamers, Hurtworld aims to punish.",
+    "description": "Hurtworld is a hardcore multiplayer survival FPS with a focus on deep survival progression that doesn't become trivial once you establish some basic needs. Built for hardcore gamers, Hurtworld aims to punish.\r\n\r\nThis egg includes the options to install Oxide\/uMod and corresponding plugins",
     "features": [
         "steam_disk_space"
     ],
@@ -24,9 +24,9 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/ptero-eggs\/installers:debian'\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## copy 32-bit steamclient.so\r\ncp -v linux32\/steamclient.so ..\/Hurtworld_Data\/Plugins\/x86\/steamclient.so\r\n\r\n## copy 64-bit steamclient.so\r\ncp -v linux64\/steamclient.so ..\/Hurtworld_Data\/Plugins\/x86_64\/steamclient.so\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n# Server Files: \/mnt\/server\r\n# Image: 'ghcr.io\/ptero-eggs\/installers:debian'\r\n# Ensure Steam credentials are set\r\nif [[ -z \"${STEAM_USER}\" ]] || [[ -z \"${STEAM_PASS}\" ]]; then\r\n    echo -e \"Steam user is not set. Using anonymous login.\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"User set to ${STEAM_USER}\"\r\nfi\r\n\r\n# Install SteamCMD\r\necho \"Downloading and installing SteamCMD...\"\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# Set ownership to prevent permission issues\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n# Install server using SteamCMD\r\necho \"Installing Hurtworld server via SteamCMD...\"\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server \\\r\n    +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} \\\r\n    $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) \\\r\n    +app_update ${SRCDS_APPID} \\\r\n    $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) \\\r\n    $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) \\\r\n    ${INSTALL_FLAGS} validate +quit\r\n\r\n# Set up Steam libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n# Copy Steam libraries to Hurtworld directories\r\nmkdir -p \/mnt\/server\/Hurtworld_Data\/Plugins\/x86\r\nmkdir -p \/mnt\/server\/Hurtworld_Data\/Plugins\/x86_64\r\ncp -v linux32\/steamclient.so \/mnt\/server\/Hurtworld_Data\/Plugins\/x86\/steamclient.so\r\ncp -v linux64\/steamclient.so \/mnt\/server\/Hurtworld_Data\/Plugins\/x86_64\/steamclient.so\r\n\r\n# Check if INSTALL_OXIDE needs to be installed\r\nif [[ \"${INSTALL_OXIDE}\" == \"1\" ]]; then\r\n    echo \"INSTALL_OXIDE is set to 1. Downloading and installing uMod\/Oxide...\"\r\n    curl -sSL -o umod.zip \"https:\/\/umod.org\/games\/hurtworld\/download\/develop\"\r\n\r\n    if [ -f umod.zip ]; then\r\n        echo \"Extracting uMod\/Oxide...\"\r\n        unzip -o umod.zip -d \/mnt\/server\r\n        rm umod.zip\r\n    else\r\n        echo \"Failed to download uMod\/Oxide!\"\r\n        exit 1  # Stop the script if Oxide fails to install\r\n    fi\r\n\r\n    # Ensure Oxide directory exists for plugins\r\n    PLUGIN_DIR=\"\/mnt\/server\/oxide\/plugins\"\r\n    mkdir -p \"$PLUGIN_DIR\"\r\n\r\n    if [[ -n \"${INSTALL_PLUGINS}\" ]]; then\r\n        IFS=',' read -ra PLUGINS <<< \"${INSTALL_PLUGINS}\"\r\n\r\n        echo \"Downloading selected Oxide plugins...\"\r\n        for PLUGIN in \"${PLUGINS[@]}\"; do\r\n            PLUGIN_NAME=$(echo \"$PLUGIN\" | sed -e 's\/^ *\/\/g' -e 's\/ *$\/\/g' -e 's\/\"\/\/g')\r\n\r\n            # url formatting\r\n            PLUGIN_FILE=\"${PLUGIN_NAME\/\/ \/}\"\r\n            PLUGIN_URL=\"https:\/\/umod.org\/plugins\/${PLUGIN_FILE}.cs\"\r\n\r\n            # Download the plugin\r\n            echo \"Downloading plugin: $PLUGIN_NAME\"\r\n            curl -sSL -o \"$PLUGIN_DIR\/${PLUGIN_FILE}.cs\" \"$PLUGIN_URL\"\r\n\r\n            # Verify the downloaded file is valid\r\n            if grep -q \"<!DOCTYPE html>\" \"$PLUGIN_DIR\/${PLUGIN_FILE}.cs\"; then\r\n                echo \"Error: Plugin '$PLUGIN_NAME' not found! Removing invalid file.\"\r\n                rm -f \"$PLUGIN_DIR\/${PLUGIN_FILE}.cs\"\r\n            else\r\n                echo \"Successfully downloaded: $PLUGIN_NAME\"\r\n            fi\r\n        done\r\n    else\r\n        echo \"INSTALL_PLUGINS is empty. No plugins will be installed.\"\r\n    fi\r\nelse\r\n    echo \"INSTALL_OXIDE is set to 0. Skipping uMod\/Oxide installation and plugin downloads.\"\r\nfi\r\n\r\n# Ensure directory exists\r\nmkdir -p \/mnt\/server\/Hurtworld_Data\/Managed\r\n\r\n## Install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "ghcr.io\/ptero-eggs\/installers:debian",
-            "entrypoint": "\/bin\/bash"
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -38,6 +38,26 @@
             "user_viewable": true,
             "user_editable": false,
             "rules": "required|in:405100",
+            "field_type": "text"
+        },
+        {
+            "name": "Include Oxide",
+            "description": "This option will allow you to automatically install Oxide\/uMod on the server.\r\nDefault value is 0, change it to a 1 to install.",
+            "env_variable": "INSTALL_OXIDE",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Install Plugins",
+            "description": "This variable allows you to automatically install Oxide plugins. \r\nFormat example: No Build Zones,Loot Chests,HW Time Control\r\nPlugins can be found at: https:\/\/umod.org\/plugins?categories=hurtworld",
+            "env_variable": "INSTALL_PLUGINS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
Added the option to install Oxide/uMod and plugins

- To enable the install of Oxide, set the 'Include Oxide' variable to 1 (default 0)
- To automatically install plugins of your choice, enter them in the 'Install Plugins' variable (default is empty)

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel