### PR TITLE
Removed java versions below 21 for the NeoForge Egg

### DIFF
--- a/minecraft/java/neoforge/egg-neoforge.json
+++ b/minecraft/java/neoforge/egg-neoforge.json
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 17": "ghcr.io\/ptero-eggs\/yolks:java_17",
         "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21",
         "java 22": "ghcr.io\/ptero-eggs\/yolks:java_22"
     },

--- a/minecraft/java/neoforge/egg-neoforge.json
+++ b/minecraft/java/neoforge/egg-neoforge.json
@@ -14,10 +14,6 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/ptero-eggs\/yolks:java_8",
-        "Java 11": "ghcr.io\/ptero-eggs\/yolks:java_11",
-        "Java 16": "ghcr.io\/ptero-eggs\/yolks:java_16",
-        "Java 17": "ghcr.io\/ptero-eggs\/yolks:java_17",
         "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21",
         "java 22": "ghcr.io\/ptero-eggs\/yolks:java_22"
     },


### PR DESCRIPTION
Removed Java versions below 21, as they are not compatible with NeoForge.

# Description

I removed all java versions below 21. They wouldn't be compatible with NeoForge and it would just crash.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [] You verify that the start command applied does not use a shell script
  * [] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel (ehh yes? i mean i imported it from this repo tho)