### PR TITLE
Update lip download URL

### DIFF
--- a/minecraft/bedrock/LeviLamina/README.md
+++ b/minecraft/bedrock/LeviLamina/README.md
@@ -3,8 +3,9 @@
 [LeviLamina](https://github.com/LiteLDev/LeviLamina) - A lightweight, modular and versatile mod loader for Minecraft Bedrock Edition, formerly known as LiteLoaderBDS
 
 # Mod installation
-On each startup the egg will look for a file called `lip-install.txt` and use [lip](https://github.com/futrime/lip) to attempt to install all specified packages.
+During install the egg will look for a file called `lip-install.txt` and use [lip](https://github.com/futrime/lip) to attempt to install all specified packages.
 The format of `lip-install.txt` is one package per line in the usual format lip expects.
+Create `lip-install.txt`, add your packages to it, then click the reinstall button.
 ## Example
 Install LeviAntiCheat version 0.3.7
 `github.com/LiteLDev/LeviAntiCheat@0.3.7`

--- a/minecraft/bedrock/LeviLamina/egg-levi-lamina.json
+++ b/minecraft/bedrock/LeviLamina/egg-levi-lamina.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-01-05T18:35:54+00:00",
+    "exported_at": "2025-03-12T15:30:18+00:00",
     "name": "LeviLamina",
     "author": "eggs@purpleflaghosting.com",
     "description": "LeviLamina is an unofficial mod loader designed to offer indispensable API support for Minecraft Bedrock Edition. It boasts a comprehensive API, an array of utility interfaces, a robust event system, and comprehensive support for basic interfaces. LeviLamina provides an expansive API, a powerful event system, and a wealth of encapsulated development infrastructure interfaces, forming a solid foundation for augmenting the Minecraft Bedrock Edition with additional gameplay features and functionalities. By leveraging mods, the process of extending Bedrock functionality becomes effortless, with a user-friendly development process and an adaptable approach.",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "# Install required packages\r\napt update\r\napt install lsb-release\r\n\r\n# Install wine\r\nwget -O \/etc\/apt\/keyrings\/winehq-archive.key https:\/\/dl.winehq.org\/wine-builds\/winehq.key\r\nwget -NP \/etc\/apt\/sources.list.d\/ https:\/\/dl.winehq.org\/wine-builds\/debian\/dists\/$(lsb_release -sc 2>\/dev\/null)\/winehq-$(lsb_release -sc 2>\/dev\/null).sources\r\napt update\r\napt install --no-install-recommends winehq-stable  -y\r\n\r\n\r\ncd \/mnt\/server || { echo \"Failed to change directory\"; exit 1; }\r\n\r\n# Install lip\r\nLIP_URL=\"https:\/\/github.com\/lippkg\/lip\/releases\/latest\/download\/lip-windows-amd64.zip\"\r\nwget $LIP_URL -O lip.zip\r\nunzip -o lip.zip lip.exe\r\nrm lip.zip\r\n\r\n\r\nif [ -n \"$VERSION\" ] && [ \"$VERSION\" != \"latest\" ]; then\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina@\"$VERSION\"\r\nelse\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina\r\nfi\r\n\r\n\r\necho \"Server Installed\"\r\n\r\nif [ -f \"lip-install.txt\" ]; then\r\n    echo \"Installing packages from lip-install.txt\"\r\n    wine lip.exe install --yes --specifiers lip-install.txt\r\n    echo \"Packages installed\"\r\nfi",
+            "script": "# Install required packages\r\napt update\r\napt install lsb-release\r\n\r\n# Install wine\r\nwget -O \/etc\/apt\/keyrings\/winehq-archive.key https:\/\/dl.winehq.org\/wine-builds\/winehq.key\r\nwget -NP \/etc\/apt\/sources.list.d\/ https:\/\/dl.winehq.org\/wine-builds\/debian\/dists\/$(lsb_release -sc 2>\/dev\/null)\/winehq-$(lsb_release -sc 2>\/dev\/null).sources\r\napt update\r\napt install --no-install-recommends winehq-stable  -y\r\n\r\n\r\ncd \/mnt\/server || { echo \"Failed to change directory\"; exit 1; }\r\n\r\n# Install lip\r\nLIP_URL=\"https:\/\/github.com\/futrime\/lip\/releases\/latest\/download\/lip-cli-win-x64.zip\"\r\nwget $LIP_URL -O lip.zip\r\nunzip -o lip.zip lip.exe\r\nrm lip.zip\r\n\r\n\r\nif [ -n \"$VERSION\" ] && [ \"$VERSION\" != \"latest\" ]; then\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina@\"$VERSION\"\r\nelse\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina\r\nfi\r\n\r\n\r\necho \"Server Installed\"\r\n\r\nif [ -f \"lip-install.txt\" ]; then\r\n    echo \"Installing packages from lip-install.txt\"\r\n    wine lip.exe install --yes --specifiers lip-install.txt\r\n    echo \"Packages installed\"\r\nfi",
             "container": "ghcr.io\/ptero-eggs\/installers:debian",
             "entrypoint": "bash"
         }

--- a/minecraft/bedrock/LeviLamina/egg-levi-lamina.json
+++ b/minecraft/bedrock/LeviLamina/egg-levi-lamina.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-03-12T15:30:18+00:00",
+    "exported_at": "2025-03-15T12:50:25+00:00",
     "name": "LeviLamina",
     "author": "eggs@purpleflaghosting.com",
     "description": "LeviLamina is an unofficial mod loader designed to offer indispensable API support for Minecraft Bedrock Edition. It boasts a comprehensive API, an array of utility interfaces, a robust event system, and comprehensive support for basic interfaces. LeviLamina provides an expansive API, a powerful event system, and a wealth of encapsulated development infrastructure interfaces, forming a solid foundation for augmenting the Minecraft Bedrock Edition with additional gameplay features and functionalities. By leveraging mods, the process of extending Bedrock functionality becomes effortless, with a user-friendly development process and an adaptable approach.",
@@ -13,7 +13,7 @@
         "ghcr.io\/ptero-eggs\/yolks:wine_latest": "ghcr.io\/ptero-eggs\/yolks:wine_latest"
     },
     "file_denylist": [],
-    "startup": "wine lip.exe install --yes --specifiers lip-install.txt ; cat | wine bedrock_server_mod.exe",
+    "startup": "cat | wine bedrock_server_mod.exe",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"server-portv6\": \"{{server.build.default.port}}\",\r\n            \"server-name\": \"{{server.build.env.SERVERNAME}}\",\r\n            \"gamemode\": \"{{server.build.env.GAMEMODE}}\",\r\n            \"difficulty\": \"{{server.build.env.DIFFICULTY}}\",\r\n            \"max-players\": \"{{server.build.env.MAXPLAYERS}}\",\r\n            \"level-name\": \"{{server.build.env.WORLDNAME}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"IPv4 supported\"\r\n}",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "# Install required packages\r\napt update\r\napt install lsb-release\r\n\r\n# Install wine\r\nwget -O \/etc\/apt\/keyrings\/winehq-archive.key https:\/\/dl.winehq.org\/wine-builds\/winehq.key\r\nwget -NP \/etc\/apt\/sources.list.d\/ https:\/\/dl.winehq.org\/wine-builds\/debian\/dists\/$(lsb_release -sc 2>\/dev\/null)\/winehq-$(lsb_release -sc 2>\/dev\/null).sources\r\napt update\r\napt install --no-install-recommends winehq-stable  -y\r\n\r\n\r\ncd \/mnt\/server || { echo \"Failed to change directory\"; exit 1; }\r\n\r\n# Install lip\r\nLIP_URL=\"https:\/\/github.com\/futrime\/lip\/releases\/latest\/download\/lip-cli-win-x64.zip\"\r\nwget $LIP_URL -O lip.zip\r\nunzip -o lip.zip lip.exe\r\nrm lip.zip\r\n\r\n\r\nif [ -n \"$VERSION\" ] && [ \"$VERSION\" != \"latest\" ]; then\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina@\"$VERSION\"\r\nelse\r\n    wine lip.exe install --yes github.com\/LiteLDev\/LeviLamina\r\nfi\r\n\r\n\r\necho \"Server Installed\"\r\n\r\nif [ -f \"lip-install.txt\" ]; then\r\n    echo \"Installing packages from lip-install.txt\"\r\n    wine lip.exe install --yes --specifiers lip-install.txt\r\n    echo \"Packages installed\"\r\nfi",
+            "script": "# Install required packages\r\napt update\r\napt install lsb-release\r\n\r\n# Install wine\r\nwget -O \/etc\/apt\/keyrings\/winehq-archive.key https:\/\/dl.winehq.org\/wine-builds\/winehq.key\r\nwget -NP \/etc\/apt\/sources.list.d\/ https:\/\/dl.winehq.org\/wine-builds\/debian\/dists\/$(lsb_release -sc 2>\/dev\/null)\/winehq-$(lsb_release -sc 2>\/dev\/null).sources\r\napt update\r\napt install --no-install-recommends winehq-stable  -y\r\n\r\n# Setup tty width so wine console output doesn't prematurely wrap\r\nstty columns 250\r\n\r\n\r\ncd \/mnt\/server || { echo \"Failed to change directory\"; exit 1; }\r\n\r\n# Install lip\r\nLIP_URL=\"https:\/\/github.com\/futrime\/lip\/releases\/latest\/download\/lip-cli-win-x64.zip\"\r\nwget $LIP_URL -O lip.zip\r\nunzip -o lip.zip lip.exe\r\nrm lip.zip\r\n\r\n\r\nif [ -n \"$VERSION\" ] && [ \"$VERSION\" != \"latest\" ]; then\r\n    wine lip.exe install github.com\/LiteLDev\/LeviLamina@\"$VERSION\"\r\nelse\r\n    wine lip.exe install github.com\/LiteLDev\/LeviLamina\r\nfi\r\n\r\n\r\necho \"Server Installed\"\r\n\r\nif [ -f \"lip-install.txt\" ]; then\r\n    for package in $(cat \"lip-install.txt\" ); do\r\n        echo \"Installing ${package} from lip-install.txt\"\r\n        wine lip.exe install \"${package}\"\r\n    done\r\n    echo \"Packages installed\"\r\nfi",
             "container": "ghcr.io\/ptero-eggs\/installers:debian",
             "entrypoint": "bash"
         }


### PR DESCRIPTION
# Description

The package filenames on GitHub for lip changed and lip has been rewritten and no longer supports the same flags.

- Updates lip download url in LeviLamina egg
- Remove the `--yes` flag as lip no longer has this flag
- Rewrite the addon/package installer segment as lip no longer has a `--specifiers ` flag to read from a file
- Remove addon/package install/update during startup due to required `--specifiers` no longer existing

Note: You now need to click reinstall to have the server install addon packages from `lip-install.txt`

