### PR TITLE
Update SpaceStation 14 Egg

### DIFF
--- a/spacestation_14/egg-spacestation14.json
+++ b/spacestation_14/egg-spacestation14.json
@@ -2,15 +2,15 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https:\/\/pterodactyleggs.com\/egg\/6735ff6b4924a4e9bbcc1f23\/download"
     },
-    "exported_at": "2024-01-03T09:40:56+01:00",
+    "exported_at": "2025-04-18T22:29:49+01:00",
     "name": "Spacestation 14",
     "author": "josdekurk@gmail.com",
     "description": "Space Station 14 tells the story of an ordinary shift on a space station gone wrong. Immerse yourself into your role, tinker with detailed systems, and survive the chaos in this round-based multiplayer role playing game.",
     "features": null,
     "docker_images": {
-        "Dotnet 8": "ghcr.io\/ptero-eggs\/yolks:dotnet_8"
+        "Dotnet 9": "ghcr.io\/ptero-eggs\/yolks:dotnet_9"
     },
     "file_denylist": [],
     "startup": ".\/Robust.Server",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\nV=$(curl -sSL https:\/\/central.spacestation14.io\/builds\/wizards\/builds.html | grep \"The version is\"  | sed -n 's\/.*<span class=\"versionNumber\">\\([^<]*\\)<\\\/span>.*\/\\1\/p')\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"linux-x64\" || echo \"linux-arm64\")\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip https:\/\/cdn.centcomm.spacestation14.com\/builds\/wizards\/builds\/${V}\/SS14.Server_${ARCH}.zip\"\r\ncurl -sSL -o server_linux.zip \"https:\/\/cdn.centcomm.spacestation14.com\/builds\/wizards\/builds\/${V}\/SS14.Server_${ARCH}.zip\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n\r\nURL=\"https:\/\/wizards.cdn.spacestation14.com\/fork\/wizards\"\r\n\r\nV=$(curl -s \"$URL\" | grep -m1 -oP '<span[^>]*class=\"[^\"]*\\bversionNumber\\b[^\"]*\"[^>]*>\\K[^<]+')\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"linux-x64\" || echo \"linux-arm64\")\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip ${URL}\/version\/${V}\/file\/SS14.Server_${ARCH}.zip\"\r\ncurl -sSL -o server_linux.zip \"${URL}\/version\/${V}\/file\/SS14.Server_${ARCH}.zip\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "ghcr.io\/ptero-eggs\/installers:debian",
             "entrypoint": "bash"
         }


### PR DESCRIPTION
This commit updates both the docker image to .NET 9, and the install script to to use the correct CDN

# Description

Per the documentation for SS14, we should now be using .NET 9 for the server, not .NET 8. Secondly, the current egg doesn't actually work. The CDN for the downloads has moved location, both in domain, and folder structure within the new domain. This PR solves both of these issues.

Closes #133 

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: My Local environment is set up to use SSH keys for a work Github account, so I used the online text editor to replace the egg JSON.
    
* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel