### PR TITLE
Update: Brickadia

### DIFF
--- a/brickadia/egg-brickadia.json
+++ b/brickadia/egg-brickadia.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-07-12T15:08:47-04:00",
+    "exported_at": "2025-07-16T16:54:26-04:00",
     "name": "Brickadia",
     "author": "odie.identity@gmail.com",
     "description": "Brickadia is a next-generation sandbox game with immense flexibility. Every creative tool - building, scripting, and more - is used right in the game, in real-time multiplayer. Build massive worlds, intricate physics contraptions, and entirely new game modes together with your friends without ever leaving the action.",
@@ -13,9 +13,9 @@
         "ghcr.io\/ptero-eggs\/yolks:mono_latest": "ghcr.io\/ptero-eggs\/yolks:mono_latest"
     },
     "file_denylist": [],
-    "startup": ".\/Brickadia\/Binaries\/Linux\/BrickadiaServer-Linux-Shipping -server -log -port={{SERVER_PORT}} -token={{SERVER_HOSTING_TOKEN}}",
+    "startup": ".\/Brickadia\/Binaries\/Linux\/BrickadiaServer-Linux-Shipping -server -log -world=\"{{WORLD_NAME}}\" -port={{SERVER_PORT}} -token={{SERVER_HOSTING_TOKEN}}",
     "config": {
-        "files": "{}",
+        "files": "{\r\n    \".config\/Epic\/Brickadia\/Saved\/Config\/LinuxServer\/GameUserSettings.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"[Server__BP_ServerSettings_General_C BP_ServerSettings_General_C].ServerName\": \"{{env.SERVER_NAME}}\",\r\n            \"[Server__BP_ServerSettings_General_C BP_ServerSettings_General_C].ServerPassword\": \"{{env.SERVER_PASSWORD}}\",\r\n            \"[Server__BP_ServerSettings_General_C BP_ServerSettings_General_C].bPubliclyListed\": \"{{env.SERVER_LIST_PUBLIC}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"LogBrickadia: Finished preloading primary assets\"\r\n}",
         "logs": "{}",
         "stop": "exit"
@@ -50,12 +50,52 @@
         },
         {
             "name": "Dedicated Server Hosting Token",
-            "description": "Your Brickadia Dedicated Server Hosting Token. This comes from in-game -> settings -> account -> 'Create Dedicated Server Hosting Token'",
+            "description": "Your Brickadia Dedicated Server Hosting Token. This comes from https:\/\/brickadia.com\/account -> \"Create Server Hosting Token\"",
             "env_variable": "SERVER_HOSTING_TOKEN",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "World",
+            "description": "(Optional) Argument which will auto-load the world with the given name on server startup, as well as auto-saving to it. The world MUST exist in \/home\/container\/.config\/Epic\/Brickadia\/Saved\/Worlds\/ before this will work. The simplest way to add a new world to this directory is to run `br.world.saveas <world name>` in the console once the server is booted. You can then use `world name` for this variable.",
+            "env_variable": "WORLD_NAME",
+            "default_value": "world",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Name",
+            "description": "The name of your server on the public server list.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "A Pterodactyl Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string|max:255",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Password",
+            "description": "(Optional) Server password that players must enter to join. Leave blank for none.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "List Server Publicly",
+            "description": "Whether or not to include the server in the public server listing.",
+            "env_variable": "SERVER_LIST_PUBLIC",
+            "default_value": "True",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:True,False",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
- Add `world` variable for auto-load / save
- Add many configuration file variables for easier setup

The Brickadia Dedicated Server binary was updated and now accepts a new `-world` parameter, which can now be set using this egg. I have also set up a few config file settings as variables that can be changed in the panel for quicker server setup and more accessibility.

The description of the `Dedicated Server Hosting Token` variable has also been updated to fix the previously incorrect instructions to obtain a server hosting token.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
* [X] The egg was exported from the panel