### PR TITLE
Updated Fabric egg to latest LTS version for installer & updated minimal Java version needed to run MC

### DIFF
--- a/minecraft/java/fabric/README.md
+++ b/minecraft/java/fabric/README.md
@@ -1,6 +1,6 @@
 # Fabric
 
-Fabric is a lightweight, experimental modding toolchain for Minecraft.
+Fabric is a modular, lightweight mod loader for Minecraft.
 
 [Fabric Website](https://fabricmc.net/)
 

--- a/minecraft/java/fabric/egg-fabric.json
+++ b/minecraft/java/fabric/egg-fabric.json
@@ -2,9 +2,9 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https:\/\/pterodactyleggs.com\/egg\/6735ff544924a4e9bbcbc6d1\/download"
     },
-    "exported_at": "2025-04-20T21:46:27+00:00",
+    "exported_at": "2025-07-22T19:22:23+00:00",
     "name": "Fabric",
     "author": "accounts@bofanodes.io",
     "description": "Fabric is a modular modding toolchain targeting Minecraft 1.14 and above, including snapshots.",
@@ -14,12 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/ptero-eggs\/yolks:java_8",
-        "Java 11": "ghcr.io\/ptero-eggs\/yolks:java_11",
-        "Java 16": "ghcr.io\/ptero-eggs\/yolks:java_16",
-        "Java 17": "ghcr.io\/ptero-eggs\/yolks:java_17",
-        "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21",
-        "java 22": "ghcr.io\/ptero-eggs\/yolks:java_22"
+        "java 24": "ghcr.io\/ptero-eggs\/yolks:java_24",
+        "java 23": "ghcr.io\/ptero-eggs\/yolks:java_23",
+        "java 22": "ghcr.io\/ptero-eggs\/yolks:java_22",
+        "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
@@ -32,7 +30,7 @@
     "scripts": {
         "installation": {
             "script": "#!\/bin\/bash\r\n# Fabric MC Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl jq unzip dos2unix wget\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Enable snapshots\r\nif [ -z \"$MC_VERSION\" ] || [ \"$MC_VERSION\" == \"latest\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)\r\nelif [ \"$MC_VERSION\" == \"snapshot\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)\r\nfi\r\n\r\nif [ -z \"$FABRIC_VERSION\" ] || [ \"$FABRIC_VERSION\" == \"latest\" ]; then\r\n  FABRIC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/installer | jq -r '.[0].version')\r\nfi\r\n\r\nif [ -z \"$LOADER_VERSION\" ] || [ \"$LOADER_VERSION\" == \"latest\" ]; then\r\n  LOADER_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/loader | jq -r '.[] | select(.stable== true )|.version' | head -n1)\r\nelif [ \"$LOADER_VERSION\" == \"snapshot\" ]; then\r\n  LOADER_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/loader | jq -r '.[] | select(.stable== false )|.version' | head -n1)\r\nfi\r\n\r\nwget -O fabric-installer.jar https:\/\/maven.fabricmc.net\/net\/fabricmc\/fabric-installer\/$FABRIC_VERSION\/fabric-installer-$FABRIC_VERSION.jar\r\njava -jar fabric-installer.jar server -mcversion $MC_VERSION -loader $LOADER_VERSION -downloadMinecraft\r\nmv server.jar minecraft-server.jar\r\nmv fabric-server-launch.jar server.jar\r\necho \"serverJar=minecraft-server.jar\" > fabric-server-launcher.properties\r\necho -e \"Install Complete\"",
-            "container": "openjdk:11-jdk-slim",
+            "container": "openjdk:21-slim",
             "entrypoint": "bash"
         }
     },

--- a/minecraft/java/fabric/egg-fabric.json
+++ b/minecraft/java/fabric/egg-fabric.json
@@ -17,7 +17,11 @@
         "java 24": "ghcr.io\/ptero-eggs\/yolks:java_24",
         "java 23": "ghcr.io\/ptero-eggs\/yolks:java_23",
         "java 22": "ghcr.io\/ptero-eggs\/yolks:java_22",
-        "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21"
+        "java 21": "ghcr.io\/ptero-eggs\/yolks:java_21",
+        "Java 17": "ghcr.io\/ptero-eggs\/yolks:java_17",
+        "Java 16": "ghcr.io\/ptero-eggs\/yolks:java_16",
+        "Java 11": "ghcr.io\/ptero-eggs\/yolks:java_11",
+        "Java 8": "ghcr.io\/ptero-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/minecraft/java/fabric/egg-fabric.json
+++ b/minecraft/java/fabric/egg-fabric.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": "https:\/\/pterodactyleggs.com\/egg\/6735ff544924a4e9bbcbc6d1\/download"
+        "update_url": null
     },
     "exported_at": "2025-07-22T19:22:23+00:00",
     "name": "Fabric",


### PR DESCRIPTION
# Description

The Fabric MC egg couldn't install the Fabric mod loader anymore because the JRE of the installer was no longer compatible with the latest Fabric jar. Also updated the runtime selection list, some Java versions wouldn't run MC anymore.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel
