### PR TITLE
Adding Dotnet 8 to Vintage Story

### DIFF
--- a/vintage_story/egg-vintage-story.json
+++ b/vintage_story/egg-vintage-story.json
@@ -4,13 +4,14 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-01-19T10:09:42-05:00",
+    "exported_at": "2025-08-25T22:18:56+02:00",
     "name": "Vintage Story",
     "author": "mail@wuffy.eu",
     "description": "Vintage Story is an uncompromising wilderness survival sandbox game inspired by lovecraftian horror themes. Find yourself in a ruined world reclaimed by nature and permeated by unnerving temporal disturbances. Relive the advent of human civilization, or take your own path.",
     "features": null,
     "docker_images": {
-        "Dotnet 7": "ghcr.io\/ptero-eggs\/yolks:dotnet_7"
+        "Dotnet 7": "ghcr.io\/ptero-eggs\/yolks:dotnet_7",
+        "Dotnet 8": "ghcr.io\/ptero-eggs\/yolks:dotnet_8"
     },
     "file_denylist": [],
     "startup": ".\/VintagestoryServer --dataPath .\/data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",


### PR DESCRIPTION
Adding Dotnet 8, the latest version doesn't support Dotnet 7 anymore.

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
