### PR TITLE
Including Dotnet 8 for Among Us - Impostor Server

### DIFF
--- a/among_us/impostor_server/egg-among-us--impostor-server.json
+++ b/among_us/impostor_server/egg-among-us--impostor-server.json
@@ -4,12 +4,13 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-03-04T15:04:21+01:00",
+    "exported_at": "2025-09-17T15:53:51+02:00",
     "name": "Among Us - Impostor Server",
     "author": "eggs@goover.dev",
     "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
     "features": null,
     "docker_images": {
+        "Dotnet_8": "ghcr.io\/ptero-eggs\/yolks:dotnet_8",
         "Dotnet_7": "ghcr.io\/ptero-eggs\/yolks:dotnet_7",
         "Dotnet_6": "ghcr.io\/ptero-eggs\/yolks:dotnet_6"
     },


### PR DESCRIPTION
Dotnet 8 is now required for the latest version of Among Us - Impostor Server

# Description

Adding dotnet 8 to the docker images

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel