### PR TITLE
Updated outdated usergroup fields description for Enshrouded egg

### DIFF
--- a/enshrouded/egg-enshrouded.json
+++ b/enshrouded/egg-enshrouded.json
@@ -57,7 +57,7 @@
             "default_value": "ChangeMe1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|not_regex:/^\\d+$/",
+            "rules": "required|string|not_regex:/^\\d+$/",
             "field_type": "text"
         },
         {
@@ -67,7 +67,7 @@
             "default_value": "ChangeMe2",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|not_regex:/^\\d+$/",
+            "rules": "required|string|not_regex:/^\\d+$/",
             "field_type": "text"
         },
         {
@@ -77,7 +77,7 @@
             "default_value": "ChangeMe3",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|not_regex:/^\\d+$/",
+            "rules": "required|string|not_regex:/^\\d+$/",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

I fixed the description of all 3 of the Enshrouded egg User Groups variables.

It was not clear why my Enshrouded server didn't start. With no apparent error, I trialed & errored my way through it and found out **you cannot set full numerical passwords for these groups**. I used to set my passwords in only numerical & since the field is declared as a "string" my guess is that somehow it gets parsed as an int and it fails. Once I started using other characters in the password fields, the server started normally. Even if only one of the 3 fields is set in only numerical characters, you are going to get the error mentioned above.
So yeah, it doesn't look like a bug as much as an unmentioned rule to keep in mind.
Hope this helps someone out there !

This PR is a description fix to potentially avoid the issue mentioned here: https://github.com/Ptero-Eggs/game-eggs/issues/288

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
<!-- If this is an egg update fill these out -->
* [X] You verify that the start command applied does not use a shell script
  * [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel