### PR TITLE
Update spacestation 14 .NET version

### DIFF
--- a/spacestation_14/egg-spacestation14.json
+++ b/spacestation_14/egg-spacestation14.json
@@ -4,13 +4,13 @@
         "version": "PTDL_v2",
         "update_url": "https:\/\/pterodactyleggs.com\/egg\/6735ff6b4924a4e9bbcc1f23\/download"
     },
-    "exported_at": "2025-04-18T22:29:49+01:00",
+    "exported_at": "2025-12-30T12:11:58+03:00",
     "name": "Spacestation 14",
     "author": "josdekurk@gmail.com",
     "description": "Space Station 14 tells the story of an ordinary shift on a space station gone wrong. Immerse yourself into your role, tinker with detailed systems, and survive the chaos in this round-based multiplayer role playing game.",
     "features": null,
     "docker_images": {
-        "Dotnet 9": "ghcr.io\/ptero-eggs\/yolks:dotnet_9"
+        "Dotnet 10": "ghcr.io\/ptero-eggs\/yolks:dotnet_10"
     },
     "file_denylist": [],
     "startup": ".\/Robust.Server",


### PR DESCRIPTION
# Description

Since spacestation 14 officially moved from .NET 9 to 10 eggs need to be updated. Without updating it wont start anyway bc new build require .NET 10.
https://github.com/space-wizards/space-station-14/pull/41855

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel