### PR TITLE
Fix OOM crashes by reserving JVM headroom inside container memory limits

### DIFF
--- a/hytale/egg-hytale.json
+++ b/hytale/egg-hytale.json
@@ -15,7 +15,7 @@
         "ghcr.io/pterodactyl/games:hytale": "ghcr.io/pterodactyl/games:hytale"
     },
     "file_denylist": [],
-    "startup": "java -XX:AOTCache=Server\/HytaleServer.aot -Xms1024M $( ((SERVER_MEMORY)) && printf %s \"-Xmx${SERVER_MEMORY - 1024}M\" ) -jar Server\/HytaleServer.jar $( ((HYTALE_ALLOW_OP)) && printf %s \"--allow-op\" ) --assets Assets.zip --bind 0.0.0.0:${SERVER_PORT}",
+    "startup": "java -XX:AOTCache=Server\/HytaleServer.aot -Xms128M $( ((SERVER_MEMORY)) && printf %s \"-Xmx${SERVER_MEMORY - 128}M\" ) -jar Server\/HytaleServer.jar $( ((HYTALE_ALLOW_OP)) && printf %s \"--allow-op\" ) --assets Assets.zip --bind 0.0.0.0:${SERVER_PORT}",
     "config": {
         "files": "{}",
         "startup": "{\n    \"done\": \"Hytale Server Booted\"\n}",


### PR DESCRIPTION
This change fixes an issue where the Hytale Pterodactyl egg would consistently crash with exit code 137 (OOM kill) when a player joined the server.

The previous startup command set -Xmx equal to the container memory limit, leaving no headroom for JVM native memory, threads, code cache, or AOT cache. In containerized environments, this results in the kernel killing the Java process during join-time memory spikes.

This update reserves a fixed amount of memory for non-heap usage by subtracting a safety buffer from SERVER_MEMORY when setting -Xmx. This prevents immediate OOM kills while keeping heap usage within safe bounds.

Result:
- Server boots reliably
- First player join no longer crashes the server
- Behavior aligns with documented minimum memory requirements in container environments

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
