### PR TITLE
chore: adding Java 25 for paper

### DIFF
--- a/minecraft/java/paper/egg-paper.json
+++ b/minecraft/java/paper/egg-paper.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-01-05T18:02:31+00:00",
+    "exported_at": "2026-01-17T21:09:57-05:00",
     "name": "Paper",
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
@@ -19,7 +19,8 @@
         "Java 16": "ghcr.io\/ptero-eggs\/yolks:java_16",
         "Java 17": "ghcr.io\/ptero-eggs\/yolks:java_17",
         "Java 21": "ghcr.io\/ptero-eggs\/yolks:java_21",
-        "Java 22": "ghcr.io\/ptero-eggs\/yolks:java_22"
+        "Java 22": "ghcr.io\/ptero-eggs\/yolks:java_22",
+        "Java 25": "ghcr.io\/pterodactyl\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
# Description

Adding Java 25 to the Paper Egg (PaperMC) under `minecraft/java/paper`. 

The docker container that is being added is the `ghcr.io/pterodactyl/yolks:java_25`.

This is needed as Minecraft after `Minecraft 26.1 Snapshot 1` will require Java 25 ([source here](https://www.minecraft.net/en-us/article/minecraft-26-1-snapshot-1#:~:text=The%20game%20now%20requires%20Java%2025)).

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: The change is just adding an additional docker container. I do not think this needs another separate branch (for now).

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel