### PR TITLE
(Subnautica Nitrox) Update Start command for newest version and fixed typo

### DIFF
--- a/subnautica_nitrox_mod/egg-subnautica.json
+++ b/subnautica_nitrox_mod/egg-subnautica.json
@@ -4,9 +4,9 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-10-10T20:39:59+02:00",
+    "exported_at": "2026-02-14T12:57:58+01:00",
     "name": "Subnautica",
-    "author": "ptero@redbananaofficial.com",
+    "author": "felixseiboldt@gmail.com",
     "description": "Subnautica is an open world survival action-adventure video game developed and published by Unknown Worlds Entertainment. In it, players are free to explore the ocean on an alien planet, known as planet 4546B, after their spaceship, the Aurora, crashes on the planet's surface.\r\n\r\nNote: NitroxMod version >=1.7.0.0 is required",
     "features": [
         "steam_disk_space"
@@ -15,7 +15,7 @@
         "ghcr.io\/ptero-eggs\/yolks:dotnet_9": "ghcr.io\/ptero-eggs\/yolks:dotnet_9"
     },
     "file_denylist": [],
-    "startup": "export HOME=\/home\/container\/subnautica; .\/nitrox\/NitroxServer-Subnautica",
+    "startup": "export HOME=\/home\/container\/subnautica; .\/nitrox\/Nitrox.Server.Subnautica",
     "config": {
         "files": "{\r\n    \"server.cfg\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"ServerPort\": \"{{server.build.default.port}}\",\r\n            \"SaveInterval\": \"{{server.build.env.SAVE_INTERVAL}}\",\r\n            \"DisableAutoSave\": \"{{server.build.env.SAVE_DISABLE}}\",\r\n            \"SaveName\": \"{{server.build.env.SAVE_NAME}}\",\r\n            \"ServerPassword\": \"{{server.build.env.SUBNAUTICA_PASSWORD}}\",\r\n            \"AdminPassword\": \"{{server.build.env.SUBNAUTICA_ADMIN_PASSWORD}}\",\r\n            \"GameMode\": \"{{server.build.env.SERVER_MODE}}\",\r\n            \"AutoPortForward\": \"{{server.build.env.PORTFORWARD_ENABLE}}\",\r\n            \"SerializerMode\": \"{{server.build.env.SERIALIZER_MODE}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server started\"\r\n}",
@@ -62,7 +62,7 @@
         },
         {
             "name": "Steam-GuardCode",
-            "description": "Yout Steam Guard Code",
+            "description": "Your Steam Guard Code",
             "env_variable": "STEAM_GUARDCODE",
             "default_value": "",
             "user_viewable": true,


### PR DESCRIPTION
# Description

The file name changed in the newest Nitrox Server, wich leads to exit code 127 all the time.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [ ] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [ ] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [ ] The egg was exported from the panel