### PR TITLE
Removal & image changes

### DIFF
--- a/vintage_story/egg-vintage-story.json
+++ b/vintage_story/egg-vintage-story.json
@@ -4,14 +4,15 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-08-25T22:18:56+02:00",
+    "exported_at": "2026-03-03T16:39:53+01:00",
     "name": "Vintage Story",
     "author": "mail@wuffy.eu",
     "description": "Vintage Story is an uncompromising wilderness survival sandbox game inspired by lovecraftian horror themes. Find yourself in a ruined world reclaimed by nature and permeated by unnerving temporal disturbances. Relive the advent of human civilization, or take your own path.",
-    "features": null,
+    "features": [],
     "docker_images": {
-        "Dotnet 7": "ghcr.io\/ptero-eggs\/yolks:dotnet_7",
-        "Dotnet 8": "ghcr.io\/ptero-eggs\/yolks:dotnet_8"
+        "Dotnet 8": "ghcr.io\/ptero-eggs\/yolks:dotnet_8",
+        "Dotnet 9": "ghcr.io\/ptero-eggs\/yolks:dotnet_9",
+        "Dotnet 10": "ghcr.io\/ptero-eggs\/yolks:dotnet_10"
     },
     "file_denylist": [],
     "startup": ".\/VintagestoryServer --dataPath .\/data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",


### PR DESCRIPTION
# Description
Removal of the EOL dotnet 7 image, added dotnet 9 and 10. Dotnet 10 is needed for the four latest pre-releases and the foreseeable future.

Thanks to [@danspire](https://github.com/danspire) for informing me

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?
  * 
* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
