### PR TITLE
Increase maximum server name from 32 to 64 length for Icarus dedicated server egg.

### DIFF
--- a/icarus/egg-icarus--dedicated.json
+++ b/icarus/egg-icarus--dedicated.json
@@ -47,7 +47,7 @@
             "default_value": "IcarusServer",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:32",
+            "rules": "required|string|max:64",
             "field_type": "text"
         },
         {

--- a/icarus/egg-icarus--dedicated.json
+++ b/icarus/egg-icarus--dedicated.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-01-19T21:39:06+01:00",
+    "exported_at": "2026-06-20T12:13:37+00:00",
     "name": "Icarus-Dedicated",
     "author": "bolverblitz@ebg.pw",
     "description": "Icarus is a survival game that with dedicated servers as a public beta",


### PR DESCRIPTION
This change provides more flexibility for server administrators when naming their Icarus servers.