### PR TITLE
Minecraft/Technic/java the 1.12.2 pack and the 1.7.10 pack Fixed (#501)

### DIFF
--- a/minecraft/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
+++ b/minecraft/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
@@ -1,10 +1,10 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T19:40:19+00:00",
+    "exported_at": "2026-04-01T06:06:29+02:00",
     "name": "The 1.12.2 Pack",
     "author": "contact@irequire.dev",
     "description": "The 1.12.2 Pack",
@@ -14,21 +14,21 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/ptero-eggs/yolks:java_8": "ghcr.io/ptero-eggs/yolks:java_8"
+        "ghcr.io\/ptero-eggs\/yolks:java_8": "ghcr.io\/ptero-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "logs": "{\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
+        "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/ptero-eggs/installers:alpine",
-            "entrypoint": "ash",
-            "script": "#!/bin/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n\r\ncd /mnt/server\r\n\r\ncurl -sS http://solder.endermedia.com/repository/downloads/the-1122-pack/the-1122-pack_$MODPACK_VERSION.zip -o the-1122-pack_$MODPACK_VERSION.zip\r\n\r\nunzip the-1122-pack_$MODPACK_VERSION.zip\r\n\r\nrm -rf the-1122-pack_$MODPACK_VERSION.zip\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/the-1122-pack\/the-1122-pack_$MODPACK_VERSION.zip -o the-1122-pack_$MODPACK_VERSION.zip\r\n\r\nunzip the-1122-pack_$MODPACK_VERSION.zip\r\n\r\nrm -rf the-1122-pack_$MODPACK_VERSION.zip\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/ptero-eggs\/installers:alpine",
+            "entrypoint": "ash"
         }
     },
     "variables": [
@@ -36,7 +36,7 @@
             "name": "Modpack Version",
             "description": "Version of the modpack to use",
             "env_variable": "MODPACK_VERSION",
-            "default_value": "1.5.5",
+            "default_value": "1.6.6",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",

--- a/minecraft/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
+++ b/minecraft/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
@@ -1,10 +1,10 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T19:40:17+00:00",
+    "exported_at": "2026-04-01T06:06:39+02:00",
     "name": "The 1.7.10 Pack",
     "author": "contact@sweplox.se",
     "description": "The 1.7.10 Pack",
@@ -14,21 +14,21 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/ptero-eggs/yolks:java_8": "ghcr.io/ptero-eggs/yolks:java_8"
+        "ghcr.io\/ptero-eggs\/yolks:java_8": "ghcr.io\/ptero-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "logs": "{\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
+        "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/ptero-eggs/installers:alpine",
-            "entrypoint": "ash",
-            "script": "#!/bin/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n\r\ncd /mnt/server\r\n\r\ncurl -sS http://solder.endermedia.com/repository/downloads/the-1710-pack/the-1710-pack_$MODPACK_VERSION.zip -o the-1710-pack_$MODPACK_VERSION.zip\r\n\r\nunzip the-1710-pack_$MODPACK_VERSION.zip\r\n\r\nrm -rf the-1710-pack_$MODPACK_VERSION.zip\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/the-1710-pack\/the-1710-pack_$MODPACK_VERSION.zip -o the-1710-pack_$MODPACK_VERSION.zip\r\n\r\nunzip the-1710-pack_$MODPACK_VERSION.zip\r\n\r\nrm -rf the-1710-pack_$MODPACK_VERSION.zip\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/ptero-eggs\/installers:alpine",
+            "entrypoint": "ash"
         }
     },
     "variables": [
@@ -36,7 +36,7 @@
             "name": "Modpack Version",
             "description": "Version of the modpack to use",
             "env_variable": "MODPACK_VERSION",
-            "default_value": "0.10.12",
+            "default_value": "0.10.15",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",


### PR DESCRIPTION
# Description

fixes #501 
Also makes the default versions the current latest
Also fixes the 1.7.10 pack as mentioned in a comment in the above issue

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel