### PR TITLE
Add RuneScape: Dragonwilds egg

### DIFF
--- a/runescape_dragonwilds/README.MD
+++ b/runescape_dragonwilds/README.MD
@@ -1,0 +1,12 @@
+# RuneScape: Dragonwilds
+
+A survival and exploration game set in the world of RuneScape, developed by Jagex. Build a base, craft gear, fight monsters and level up your skills in a co-op open world. Currently in Early Access.
+
+> ⚠️ The server requires a valid `OwnerId` to start. Find it in-game at **Settings → bottom of the screen**.
+
+## Server Ports
+
+| Port | Default | Protocol |
+|------|---------|----------|
+| Game | 25565 | UDP |
+| Query | 27015 | UDP |

--- a/runescape_dragonwilds/README.MD
+++ b/runescape_dragonwilds/README.MD
@@ -8,5 +8,5 @@ A survival and exploration game set in the world of RuneScape, developed by Jage
 
 | Port | Default | Protocol |
 |------|---------|----------|
-| Game | 25565 | UDP |
+| Game | 7777 | UDP |
 | Query | 27015 | UDP |

--- a/runescape_dragonwilds/egg-runescape-dragonwilds.json
+++ b/runescape_dragonwilds/egg-runescape-dragonwilds.json
@@ -4,26 +4,25 @@
     "version": "PTDL_v2",
     "update_url": null
   },
-  "exported_at": "2026-04-02T22:50:00+02:00",
+  "exported_at": "2026-04-02T23:23:00+02:00",
   "name": "RuneScape: Dragonwilds",
   "author": "c4rl0s@gamzyhost",
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "description": "RuneScape: Dragonwilds Dedicated Server. A survival and exploration game developed by Jagex. Requires Steam AppID 4019830. | Egg created by c4rl0s @ GamzyHost",
+  "description": "RuneScape: Dragonwilds Dedicated Server. A survival and exploration game developed by Jagex. | Egg created by c4rl0s @ GamzyHost",
   "features": [],
   "docker_images": {
     "ghcr.io/parkervcp/steamcmd:debian": "ghcr.io/parkervcp/steamcmd:debian"
   },
   "file_denylist": [],
-  "startup": "./RSDragonwildsServer.sh -log -NewConsole -port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}}",
+  "startup": "./RSDragonwilds/Binaries/Linux/*-Linux-Shipping RSDragonwilds -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}}",
   "config": {
-    "files": "{}",
-    "startup": "{\r\n    \"done\": \"Server is up and running\"\r\n}",
+    "files": "{\r\n    \"RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"[/Script/Dominion.DedicatedServerSettings].OwnerId\": \"{{server.build.env.OWNER_ID}}\",\r\n            \"[/Script/Dominion.DedicatedServerSettings].WorldPassword\": \"{{server.build.env.WORLD_PASSWORD}}\",\r\n            \"[/Script/Dominion.DedicatedServerSettings].AdminPassword\": \"{{server.build.env.ADMIN_PASSWORD}}\",\r\n            \"[/Script/Dominion.DedicatedServerSettings].ServerName\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"[/Script/Dominion.DedicatedServerSettings].DefaultWorldName\": \"{{server.build.env.DEFAULT_WORLD_NAME}}\",\r\n            \"[/Script/Dominion.DedicatedServerSettings].MaxPlayers\": \"{{server.build.env.MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
+    "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",
     "logs": "{}",
     "stop": "^C"
   },
   "scripts": {
     "installation": {
-      "script": "#!/bin/bash\r\n# RuneScape: Dragonwilds - Install Script\r\n# Egg created by c4rl0s @ GamzyHost\r\n# SteamCMD AppID: 4019830\r\n\r\n## install steamcmd\r\nif [ ! -d /mnt/server/steamcmd ]; then\r\n    mkdir -p /mnt/server/steamcmd\r\nfi\r\n\r\ncd /mnt/server/steamcmd\r\ncurl -sqL \"https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\" | tar zxvf -\r\n\r\n## install/update game\r\n./steamcmd.sh \\\r\n    +force_install_dir /mnt/server \\\r\n    +login anonymous \\\r\n    +app_update 4019830 validate \\\r\n    +quit\r\n\r\n## create config dirs\r\nmkdir -p /mnt/server/RSDragonwilds/Saved/Config/LinuxServer\r\nmkdir -p /mnt/server/RSDragonwilds/Saved/Savegames\r\n\r\n## create default config if not exists\r\nCONFIG_FILE=\"/mnt/server/RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini\"\r\nif [ ! -f \"$CONFIG_FILE\" ]; then\r\n    cat > \"$CONFIG_FILE\" << 'EOF'\r\n[/Script/RSDragonwilds.RSDWGameMode]\r\nOwnerId=CHANGE_ME\r\nServerName=My Dragonwilds Server\r\nDefaultWorldName=My World\r\nAdminPassword=change_me\r\nWorldPassword=\r\nMaxPlayers=6\r\nEOF\r\nfi\r\n\r\necho \"--> Installation complete. Egg created by c4rl0s @ GamzyHost\"\r\necho \"--> Edit RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini before starting.\"",
+      "script": "#!/bin/bash\r\n# RuneScape: Dragonwilds - Install Script\r\n# Egg created by c4rl0s @ GamzyHost\r\n# SteamCMD AppID: 4019830\r\n\r\n## Download and install SteamCMD\r\ncd /tmp\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\nmkdir -p /mnt/server/steamcmd\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\ncd /mnt/server/steamcmd\r\n\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## Install game server\r\n./steamcmd.sh \\\r\n    +force_install_dir /mnt/server \\\r\n    +login anonymous \\\r\n    +app_update 4019830 \\\r\n    $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) \\\r\n    validate \\\r\n    +exit\r\n\r\n## Copy steamclient libraries\r\nmkdir -p /mnt/server/.steam/sdk{32,64}\r\ncp -v linux32/steamclient.so /mnt/server/.steam/sdk32/steamclient.so\r\ncp -v linux64/steamclient.so /mnt/server/.steam/sdk64/steamclient.so\r\n\r\n## Verify installation and make binary executable\r\ncd /mnt/server/RSDragonwilds/Binaries/Linux\r\ncount=$(find . -maxdepth 1 -name '*-Linux-Shipping' -type f -executable | wc -l)\r\nif [[ $count -eq 0 ]]; then\r\n    echo -e \"\\n\\nSteamCMD failed to install the RuneScape: Dragonwilds Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nelse\r\n    chmod +x *-Linux-Shipping\r\nfi\r\n\r\n## Create config directory and file\r\nmkdir -p /mnt/server/RSDragonwilds/Saved/Config/LinuxServer\r\ntouch /mnt/server/RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini\r\n\r\necho -e \"\\nRuneScape: Dragonwilds installation complete.\"\r\necho -e \"Egg created by c4rl0s @ GamzyHost\\n\"",
       "container": "ghcr.io/parkervcp/installers:debian",
       "entrypoint": "bash"
     }
@@ -36,7 +35,7 @@
       "default_value": "",
       "user_viewable": true,
       "user_editable": true,
-      "rules": "required|string|max:128",
+      "rules": "required|string|max:32",
       "field_type": "text"
     },
     {
@@ -46,17 +45,17 @@
       "default_value": "My Dragonwilds Server",
       "user_viewable": true,
       "user_editable": true,
-      "rules": "required|string|max:64",
+      "rules": "required|string|max:32",
       "field_type": "text"
     },
     {
       "name": "Default World Name",
-      "description": "Name of the world created automatically on first launch. Cannot be changed after the first start.",
+      "description": "Name of the world created on first launch. Cannot be changed after the first start.",
       "env_variable": "DEFAULT_WORLD_NAME",
       "default_value": "My World",
       "user_viewable": true,
       "user_editable": true,
-      "rules": "required|string|max:64",
+      "rules": "required|string|max:20",
       "field_type": "text"
     },
     {
@@ -97,6 +96,16 @@
       "user_viewable": true,
       "user_editable": true,
       "rules": "required|integer|min:1024|max:65535",
+      "field_type": "text"
+    },
+    {
+      "name": "Branch Name",
+      "description": "Leave empty for default branch. Use 'experimental' for the experimental branch.",
+      "env_variable": "SRCDS_BETAID",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string|in:experimental",
       "field_type": "text"
     }
   ]

--- a/runescape_dragonwilds/egg-runescape-dragonwilds.json
+++ b/runescape_dragonwilds/egg-runescape-dragonwilds.json
@@ -1,0 +1,103 @@
+{
+  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY - Created by c4rl0s | GamzyHost",
+  "meta": {
+    "version": "PTDL_v2",
+    "update_url": null
+  },
+  "exported_at": "2026-04-02T22:50:00+02:00",
+  "name": "RuneScape: Dragonwilds",
+  "author": "c4rl0s@gamzyhost",
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "description": "RuneScape: Dragonwilds Dedicated Server. A survival and exploration game developed by Jagex. Requires Steam AppID 4019830. | Egg created by c4rl0s @ GamzyHost",
+  "features": [],
+  "docker_images": {
+    "ghcr.io/parkervcp/steamcmd:debian": "ghcr.io/parkervcp/steamcmd:debian"
+  },
+  "file_denylist": [],
+  "startup": "./RSDragonwildsServer.sh -log -NewConsole -port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}}",
+  "config": {
+    "files": "{}",
+    "startup": "{\r\n    \"done\": \"Server is up and running\"\r\n}",
+    "logs": "{}",
+    "stop": "^C"
+  },
+  "scripts": {
+    "installation": {
+      "script": "#!/bin/bash\r\n# RuneScape: Dragonwilds - Install Script\r\n# Egg created by c4rl0s @ GamzyHost\r\n# SteamCMD AppID: 4019830\r\n\r\n## install steamcmd\r\nif [ ! -d /mnt/server/steamcmd ]; then\r\n    mkdir -p /mnt/server/steamcmd\r\nfi\r\n\r\ncd /mnt/server/steamcmd\r\ncurl -sqL \"https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\" | tar zxvf -\r\n\r\n## install/update game\r\n./steamcmd.sh \\\r\n    +force_install_dir /mnt/server \\\r\n    +login anonymous \\\r\n    +app_update 4019830 validate \\\r\n    +quit\r\n\r\n## create config dirs\r\nmkdir -p /mnt/server/RSDragonwilds/Saved/Config/LinuxServer\r\nmkdir -p /mnt/server/RSDragonwilds/Saved/Savegames\r\n\r\n## create default config if not exists\r\nCONFIG_FILE=\"/mnt/server/RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini\"\r\nif [ ! -f \"$CONFIG_FILE\" ]; then\r\n    cat > \"$CONFIG_FILE\" << 'EOF'\r\n[/Script/RSDragonwilds.RSDWGameMode]\r\nOwnerId=CHANGE_ME\r\nServerName=My Dragonwilds Server\r\nDefaultWorldName=My World\r\nAdminPassword=change_me\r\nWorldPassword=\r\nMaxPlayers=6\r\nEOF\r\nfi\r\n\r\necho \"--> Installation complete. Egg created by c4rl0s @ GamzyHost\"\r\necho \"--> Edit RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini before starting.\"",
+      "container": "ghcr.io/parkervcp/installers:debian",
+      "entrypoint": "bash"
+    }
+  },
+  "variables": [
+    {
+      "name": "Owner ID",
+      "description": "Your RuneScape: Dragonwilds Player ID. Find it in-game at the bottom of the Settings menu. The server WILL NOT start without this value.",
+      "env_variable": "OWNER_ID",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|max:128",
+      "field_type": "text"
+    },
+    {
+      "name": "Server Name",
+      "description": "The name of your server as it appears in the server browser.",
+      "env_variable": "SERVER_NAME",
+      "default_value": "My Dragonwilds Server",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|max:64",
+      "field_type": "text"
+    },
+    {
+      "name": "Default World Name",
+      "description": "Name of the world created automatically on first launch. Cannot be changed after the first start.",
+      "env_variable": "DEFAULT_WORLD_NAME",
+      "default_value": "My World",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|max:64",
+      "field_type": "text"
+    },
+    {
+      "name": "World Password",
+      "description": "Optional. Password required to join the world. Leave empty for a public server.",
+      "env_variable": "WORLD_PASSWORD",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string|max:64",
+      "field_type": "text"
+    },
+    {
+      "name": "Admin Password",
+      "description": "Any player who enters this password in Server Management will be granted admin privileges.",
+      "env_variable": "ADMIN_PASSWORD",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|max:64",
+      "field_type": "text"
+    },
+    {
+      "name": "Max Players",
+      "description": "Maximum number of simultaneous players. Recommended maximum: 6.",
+      "env_variable": "MAX_PLAYERS",
+      "default_value": "6",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|integer|min:1|max:6",
+      "field_type": "text"
+    },
+    {
+      "name": "Query Port",
+      "description": "UDP port used by Steam for server queries.",
+      "env_variable": "QUERY_PORT",
+      "default_value": "27015",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|integer|min:1024|max:65535",
+      "field_type": "text"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a dedicated server egg for RuneScape: Dragonwilds.

- Steam AppID: 4019830
- Docker: ghcr.io/parkervcp/steamcmd:debian
- container: ghcr.io/parkervcp/installers:debian