### PR TITLE
Adding the new Direct IP Connection option

### DIFF
--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-04-18T17:43:34+02:00",
+    "exported_at": "2026-04-19T15:11:15+02:00",
     "name": "Windrose",
     "author": "ptero@redbananaofficial.com",
     "description": "Embark on a PvE survival adventure in the Age of Piracy. Fight on land and sea, solo or with friends. Build, craft and explore vast open world filled with dark secrets. Master soulslite combat and take on challenging bosses, command your ship and plunder unspoken treasures!",
@@ -17,7 +17,7 @@
     "file_denylist": [],
     "startup": "wine \/home\/container\/R5\/Binaries\/Win64\/WindroseServer-Win64-Shipping.exe -log & WINDROSE_PID=$!; tail -c0 -F \/home\/container\/R5\/Saved\/Logs\/R5.log --pid=$WINDROSE_PID",
     "config": {
-        "files": "{\r\n    \"R5\/ServerDescription.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ServerDescription_Persistent.ServerName\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"ServerDescription_Persistent.InviteCode\": \"{{server.build.env.INVITE_CODE}}\",\r\n            \"ServerDescription_Persistent.IsPasswordProtected\": \"{{server.build.env.SERVER_PASSWORD_PROTECTED}}\",\r\n            \"ServerDescription_Persistent.Password\": \"{{server.build.env.SERVER_PASSWORD}}\",\r\n            \"ServerDescription_Persistent.MaxPlayerCount\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerDescription_Persistent.P2pProxyAddress\": \"{{server.build.env.P2P_PROXY}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"R5\/ServerDescription.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ServerDescription_Persistent.ServerName\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"ServerDescription_Persistent.InviteCode\": \"{{server.build.env.INVITE_CODE}}\",\r\n            \"ServerDescription_Persistent.IsPasswordProtected\": \"{{server.build.env.SERVER_PASSWORD_PROTECTED}}\",\r\n            \"ServerDescription_Persistent.Password\": \"{{server.build.env.SERVER_PASSWORD}}\",\r\n            \"ServerDescription_Persistent.MaxPlayerCount\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerDescription_Persistent.P2pProxyAddress\": \"{{server.build.env.P2P_PROXY}}\",\r\n            \"ServerDescription_Persistent.UseDirectConnection\": \"{{server.build.env.USE_DIRECT_CONNECTION}}\",\r\n            \"ServerDescription_Persistent.DirectConnectionServerAddress\": \"{{server.build.default.ip}}\",\r\n            \"ServerDescription_Persistent.DirectConnectionServerPort\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Bringing up level for play took\"\r\n}",
         "logs": "{}",
         "stop": "^C"
@@ -38,6 +38,16 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:40",
+            "field_type": "text"
+        },
+        {
+            "name": "Use Direct Connection",
+            "description": "Enable direct connection instead of invite codes, when set to 1 (enabled) it will disable the use of the Invite Code.",
+            "env_variable": "USE_DIRECT_CONNECTION",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
             "field_type": "text"
         },
         {
@@ -72,7 +82,7 @@
         },
         {
             "name": "Invite code",
-            "description": "Invite code (0-9, a-z, A-Z). Min 6 chars, case sensitive. Leaving it empty will default the server to a random generated invite code",
+            "description": "Invite code (0-9, a-z, A-Z). Min 6 chars, case sensitive. Leave empty to generate a random code on each server start. Ignored when Direct Connection is enabled.",
             "env_variable": "INVITE_CODE",
             "default_value": "",
             "user_viewable": true,


### PR DESCRIPTION
# Description

The server now allows you to enable ''UseDirectConnection'' which will disable the use of the invite code, and use the serverip:port allocated to your server for direct connection.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel