### PR TITLE
Add insecure auth mode

### DIFF
--- a/hytale/egg-hytale.json
+++ b/hytale/egg-hytale.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-01-13T05:17:28+00:00",
+    "exported_at": "2026-04-22T23:58:04+00:00",
     "name": "Hytale",
     "author": "hello@pterodactyl.io",
     "description": "Set out on an adventure built for both creation and play. Hytale blends the freedom of a sandbox with the momentum of an RPG: explore a procedurally generated world full of dungeons, secrets, and a variety of creatures, then shape it block by block.",
@@ -12,7 +12,7 @@
         "java_version"
     ],
     "docker_images": {
-        "ghcr.io/pterodactyl/games:hytale": "ghcr.io/pterodactyl/games:hytale"
+        "ghcr.io\/pterodactyl\/games:hytale": "ghcr.io\/pterodactyl\/games:hytale"
     },
     "file_denylist": [],
     "startup": "java $( ((USE_AOT_CACHE)) && printf %s \"-XX:AOTCache=Server\/HytaleServer.aot\" ) -Xms128M $( ((SERVER_MEMORY)) && printf %s \"-Xmx${SERVER_MEMORY}M\" ) -jar Server\/HytaleServer.jar $( ((HYTALE_ALLOW_OP)) && printf %s \"--allow-op\" ) $( ((HYTALE_ACCEPT_EARLY_PLUGINS)) && printf %s \"--accept-early-plugins\" ) $( ((DISABLE_SENTRY)) && printf %s \"--disable-sentry\" ) --auth-mode ${HYTALE_AUTH_MODE} --assets Assets.zip --bind 0.0.0.0:${SERVER_PORT}",
@@ -20,12 +20,12 @@
         "files": "{}",
         "startup": "{\n    \"done\": \"Hytale Server Booted\"\n}",
         "logs": "{}",
-        "stop": "/stop"
+        "stop": "\/stop"
     },
     "scripts": {
         "installation": {
             "script": "#!\/bin\/ash\nset -e\n\nmkdir -p \/mnt\/server\ncd \/mnt\/server\n\necho -e \"Downloading Hytale Downloader CLI...\"\n\nDOWNLOAD_URL=\"https:\/\/downloader.hytale.com\/hytale-downloader.zip\"\n\nrm -f hytale-downloader.zip\ncurl -o hytale-downloader.zip $DOWNLOAD_URL\nunzip -o hytale-downloader.zip -d hytale-downloader\nmv hytale-downloader\/hytale-downloader-linux-amd64 hytale-downloader\/hytale-downloader-linux\nchmod 555 hytale-downloader\/hytale-downloader-linux\n\necho -e \"Verifying Hytale Downloader installation...\"\n\necho -e \"Hytale Downloader version: `.\/hytale-downloader\/hytale-downloader-linux -version`\"\n\necho -e \"Hytale Downloader installed successfully.\"",
-            "container": "ghcr.io/pterodactyl/installers:alpine",
+            "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }
     },
@@ -47,7 +47,7 @@
             "default_value": "authenticated",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:authenticated,offline",
+            "rules": "required|string|in:authenticated,offline,insecure",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

Allow the value "insecure" for the HYTALE_AUTH_MODE argument (`--auth-mode`). This authentication mode is supported by Hytale servers and should be an available option in the Service Configuration/Auth Mode setting. This mode is, for example, used for [OrbisProxy](https://github.com/OrbisProxy/proxy).

There are also some escapes in the PR because they are part of the new egg export.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel