### PR TITLE
fix(windrose): allow configuring P2P proxy address

### DIFF
--- a/windrose/README.md
+++ b/windrose/README.md
@@ -21,3 +21,15 @@ Players can connect by:
 ## Server Ports
 - With the Invite Code, ports are dynamically assigned via NAT punch-through. Ensure your router supports UPnP. Disable proxy/VPN temporarily if connections fail.
 - With Direct Connect it will use your servers allocated Game Port instead.
+
+### Invite code / ICE troubleshooting
+
+If invite-code connections fail with errors similar to:
+
+```text
+Cannot resolve addresses for host <hostname>. Status message Host not found.
+Error on getting local ICE candidates for BL.
+
+set the P2P Proxy Address variable to the server public IP or allocation IP instead of 127.0.0.1.
+
+Windrose uses P2pProxyAddress as the IP address for P2P/ICE listening sockets. 127.0.0.1 may work only when the P2P proxy is intentionally internal.

--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -102,12 +102,12 @@
         },
         {
             "name": "P2P PROXY",
-            "description": "Don't change this",
+            "description": "IP address used by Windrose for P2P/ICE listening sockets. For invite-code servers on host-network/VPS setups, set this to the server public or allocation IP. Use 127.0.0.1 only when the P2P proxy is intentionally internal.",
             "env_variable": "P2P_PROXY",
             "default_value": "127.0.0.1",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:127.0.0.1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
             "field_type": "text"
         },
         {

--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -101,7 +101,7 @@
             "field_type": "text"
         },
         {
-            "name": "P2P PROXY",
+            "name": "P2P Proxy Address",
             "description": "IP address used by Windrose for P2P/ICE listening sockets. For invite-code servers on host-network/VPS setups, set this to the server public or allocation IP. Use 127.0.0.1 only when the P2P proxy is intentionally internal.",
             "env_variable": "P2P_PROXY",
             "default_value": "127.0.0.1",


### PR DESCRIPTION
## Description

This PR makes the Windrose `P2P_PROXY` / `P2pProxyAddress` variable configurable instead of hard-locking it to `127.0.0.1`.

The current egg sets:

required|string|in:127.0.0.1

and marks the variable as not user-editable. This can break invite-code / ICE connections on host-network VPS setups, because Windrose uses P2pProxyAddress as the IP address for P2P/ICE listening sockets.

The official Windrose dedicated server guide describes P2pProxyAddress as the “IP address used for listening sockets” and shows a non-loopback LAN IP in the example config.

Tested

Tested on a Pterodactyl Windrose server using host networking.

Before changing P2P_PROXY:

P2P_PROXY=127.0.0.1

The server registered successfully, but player connection through invite code failed during ICE candidate gathering:

Cannot resolve addresses for host <server UUID>. Status message Host not found.
Error on getting local ICE candidates for BL.

After changing the deployed egg variable:

P2P_PROXY=<server public/allocation IP>

invite-code connection worked.

Changes
Renamed P2P PROXY to P2P Proxy Address.
Updated the variable description.
Made P2P_PROXY viewable/editable.
Removed the in:127.0.0.1 validation restriction.
Added README troubleshooting notes for invite-code / ICE failures.