### PR TITLE
egg: Conan Exiles Enhanced (UE5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Below is a categorized list of games with links to their respective server confi
 
 #### [Colony Survival](./colony_survival)
 
-#### [Conan Exiles](./conan_exiles)
+#### Conan Exiles
+* [Conan Exiles](./conan_exiles)
+* [Conan Exiles Enhanced (UE5)](./conan_exiles)
 
 #### [Contagion)](./contagion)
 

--- a/conan_exiles/README.md
+++ b/conan_exiles/README.md
@@ -45,16 +45,11 @@ UE5's Lumen and Nanite increase baseline memory usage 15–25% over UE4. Plan fo
 
 ## Server Ports
 
-| Port            | default |
-|-----------------|---------|
-| Game            | 7777    |
-| Game +1         | 7778    |
-| UDP Server query| 27015   |
-| RCON            | 25575   |
+Same as the original Conan Exiles ports above (7777, 7778, 27015, 25575).
 
 ## Steam Workshop mods
 
-Set the `MOD_LIST` egg variable to a comma-separated list of Steam Workshop IDs (e.g. `1369743238,2287499941`). The install script downloads each anonymously via SteamCMD, copies the `.pak` files into `ConanSandbox/Mods/` without renaming them (renaming breaks loading per Inflexion), and writes `modlist.txt`.
+Unlike the original egg, the Enhanced egg downloads Steam Workshop mods automatically. Set the `MOD_LIST` egg variable to a comma-separated list of Steam Workshop IDs (e.g. `1369743238,2287499941`). The install script downloads each anonymously via SteamCMD, copies the `.pak` files into `ConanSandbox/Mods/` without renaming them (renaming breaks loading per Inflexion), and writes `modlist.txt`.
 
 UE4 mods are silently ignored by Enhanced — only UE5-rebuilt mods will load. Most popular mods (Pippi, Fashionist, Hosav's UI) had Enhanced-compatible re-uploads available within hours of launch.
 

--- a/conan_exiles/README.md
+++ b/conan_exiles/README.md
@@ -28,3 +28,42 @@ See: [Here](https://www.conanexiles.com/dedicated-servers/)
 
 
 ## More information can be found [here](https://forums.funcom.com/t/conan-exiles-dedicated-server-app-latest-version-1-0-21/21699)
+
+---
+
+# Conan Exiles Enhanced (UE5)
+
+Conan Exiles Enhanced is the May 5, 2026 Unreal Engine 5 rebuild of Conan Exiles, developed by Funcom with Inflexion Games. The egg `egg-conan-exiles-enhanced.json` in this folder runs the native Linux dedicated server binary that Funcom shipped with Enhanced — no Wine required, unlike the original egg above.
+
+**Use the Enhanced egg** if you want the current UE5 build (the default Steam download for App ID `443030`).
+
+**Use the original egg** if you specifically need the UE4 build, accessible via the `conan-exiles-legacy` Steam beta branch.
+
+## Minimum RAM warning
+
+UE5's Lumen and Nanite increase baseline memory usage 15–25% over UE4. Plan for at least 12 GB; 16 GB recommended if running mods.
+
+## Server Ports
+
+| Port            | default |
+|-----------------|---------|
+| Game            | 7777    |
+| Game +1         | 7778    |
+| UDP Server query| 27015   |
+| RCON            | 25575   |
+
+## Steam Workshop mods
+
+Set the `MOD_LIST` egg variable to a comma-separated list of Steam Workshop IDs (e.g. `1369743238,2287499941`). The install script downloads each anonymously via SteamCMD, copies the `.pak` files into `ConanSandbox/Mods/` without renaming them (renaming breaks loading per Inflexion), and writes `modlist.txt`.
+
+UE4 mods are silently ignored by Enhanced — only UE5-rebuilt mods will load. Most popular mods (Pippi, Fashionist, Hosav's UI) had Enhanced-compatible re-uploads available within hours of launch.
+
+## Known issues since Enhanced launch
+
+- **Legacy/UE4 mods cause OOM at boot** on builds before the May 6, 2026 hotfix. Fixed by Funcom.
+- **Stale `bUseBuildIdOverride` lines** in migrated `Engine.ini` files from UE4 servers block client connections. Remove the `[OnlineSubsystem] bUseBuildIdOverride=` and `BuildIdOverride=` lines.
+- **`-MULTIHOME=<ip>` server browser registration** required also passing `-MULTIHOMEHTTP=<ip>` on builds before the May 13, 2026 hotfix.
+- **`game.db` → `game_0.db` rename** happens automatically on first boot if migrating a UE4 save. Update any backup scripts to use the new filename.
+- **First boot is slow** — UE5 asset preload plus potential save migration. Don't kill the process during first start; it can corrupt the save.
+
+## More information can be found [here](https://exiles-enhanced.inflexion.io/servers/)

--- a/conan_exiles/egg-conan-exiles-enhanced.json
+++ b/conan_exiles/egg-conan-exiles-enhanced.json
@@ -4,18 +4,18 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-05-13T17:35:54-04:00",
+    "exported_at": "2026-05-13T22:00:00+00:00",
     "name": "Conan Exiles Enhanced",
     "author": "arrow816@gmail.com",
-    "description": "Conan Exiles Enhanced (UE5) dedicated server with Steam Workshop mod support. Native Linux server binary - no Wine required. Auto-updates game files on every boot when AUTO_UPDATE is 1.",
+    "description": "Conan Exiles Enhanced (UE5) dedicated server with Steam Workshop mod support. Native Linux server binary, no Wine required. Mods auto-sync on every boot when MOD_LIST is set.",
     "features": [
         "steam_disk_space"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
+        "ghcr.io/parkervcp/steamcmd:debian": "ghcr.io/parkervcp/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": ".\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping ConanSandbox -log -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -RconPort={{RCON_PORT}} -ServerName=\"{{SRV_NAME}}\" -MaxPlayers={{MAX_PLAYERS}}",
+    "startup": "bash -c 'if [ -n \"${MOD_LIST}\" ]; then IFS=\",\" read -ra MODS <<< \"${MOD_LIST}\"; CMDS=\"\"; for id in \"${MODS[@]}\"; do id=$(echo \"$id\" | tr -d \"[:space:]\"); [ -n \"$id\" ] && CMDS=\"$CMDS +workshop_download_item ${WORKSHOP_APPID} $id validate\"; done; ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous $CMDS +quit; > ./ConanSandbox/Mods/modlist.txt; for id in \"${MODS[@]}\"; do id=$(echo \"$id\" | tr -d \"[:space:]\"); SRC=\"./steamapps/workshop/content/${WORKSHOP_APPID}/$id\"; [ -d \"$SRC\" ] && for pak in \"$SRC\"/*.pak; do [ -f \"$pak\" ] && cp -f \"$pak\" ./ConanSandbox/Mods/ && echo \"*$(basename $pak)\" >> ./ConanSandbox/Mods/modlist.txt; done; done; fi && ./ConanSandbox/Binaries/Linux/ConanSandboxServer-Linux-Shipping ConanSandbox -log -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -RconPort={{RCON_PORT}} -ServerName=\"{{SRV_NAME}}\" -MaxPlayers={{MAX_PLAYERS}}'",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Log file open\"\r\n}",
@@ -24,15 +24,15 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Conan Exiles Enhanced install script - native Linux\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n\techo -e \"steam user is not set.\\n\"\r\n\techo -e \"Using anonymous user.\\n\"\r\n\tSTEAM_USER=anonymous\r\n\tSTEAM_PASS=\"\"\r\n\tSTEAM_AUTH=\"\"\r\nelse\r\n\techo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps\r\ncd \/mnt\/server\/steamcmd\r\n\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## ensure Linux binary is executable\r\nif [ -f \/mnt\/server\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping ]; then\r\n\tchmod +x \/mnt\/server\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping\r\nfi\r\n\r\n## seed directories and config files\r\nmkdir -p \/mnt\/server\/ConanSandbox\/Saved\/Config\/LinuxServer\r\nmkdir -p \/mnt\/server\/ConanSandbox\/Mods\r\n\r\n## seed ServerSettings.ini with the password (blank = no password)\r\nSS_INI=\"\/mnt\/server\/ConanSandbox\/Saved\/Config\/LinuxServer\/ServerSettings.ini\"\r\nif [ ! -f \"${SS_INI}\" ]; then\r\n\t{\r\n\t\techo \"[ServerSettings]\"\r\n\t\techo \"ServerName=${SRV_NAME}\"\r\n\t\techo \"ServerPassword=${SRV_PW}\"\r\n\t\techo \"MaxPlayers=${MAX_PLAYERS:-40}\"\r\n\t} > \"${SS_INI}\"\r\nfi\r\n\r\n## download workshop mods\r\nif [ -n \"${MOD_LIST}\" ]; then\r\n\techo \"Downloading workshop mods: ${MOD_LIST}\"\r\n\tIFS=',' read -ra MODS <<< \"${MOD_LIST}\"\r\n\tMOD_CMDS=\"\"\r\n\tfor id in \"${MODS[@]}\"; do\r\n\t\tid=$(echo \"${id}\" | tr -d '[:space:]')\r\n\t\tif [ -n \"${id}\" ]; then\r\n\t\t\tMOD_CMDS=\"${MOD_CMDS} +workshop_download_item 440900 ${id} validate\"\r\n\t\tfi\r\n\tdone\r\n\tif [ -n \"${MOD_CMDS}\" ]; then\r\n\t\t.\/steamcmd.sh +force_install_dir \/mnt\/server +login anonymous ${MOD_CMDS} +quit || echo \"Some mods failed.\"\r\n\tfi\r\n\t: > \/mnt\/server\/ConanSandbox\/Mods\/modlist.txt\r\n\tfor id in \"${MODS[@]}\"; do\r\n\t\tid=$(echo \"${id}\" | tr -d '[:space:]')\r\n\t\tif [ -n \"${id}\" ]; then\r\n\t\t\tSRC=\"\/mnt\/server\/steamapps\/workshop\/content\/440900\/${id}\"\r\n\t\t\tif [ -d \"${SRC}\" ]; then\r\n\t\t\t\tfor pak in \"${SRC}\"\/*.pak; do\r\n\t\t\t\t\tif [ -f \"${pak}\" ]; then\r\n\t\t\t\t\t\tNAME=$(basename \"${pak}\")\r\n\t\t\t\t\t\tcp -fv \"${pak}\" \"\/mnt\/server\/ConanSandbox\/Mods\/${NAME}\"\r\n\t\t\t\t\t\techo \"*${NAME}\" >> \/mnt\/server\/ConanSandbox\/Mods\/modlist.txt\r\n\t\t\t\t\tfi\r\n\t\t\t\tdone\r\n\t\t\tfi\r\n\t\tfi\r\n\tdone\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "script": "#!/bin/bash\r\n# Conan Exiles Enhanced install script - native Linux\r\n# Server Files: /mnt/server\r\n# Image to install with is 'ghcr.io/parkervcp/installers:debian'\r\n\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n\techo -e \"steam user is not set.\\n\"\r\n\techo -e \"Using anonymous user.\\n\"\r\n\tSTEAM_USER=anonymous\r\n\tSTEAM_PASS=\"\"\r\n\tSTEAM_AUTH=\"\"\r\nelse\r\n\techo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\nmkdir -p /mnt/server/steamapps\r\ncd /mnt/server/steamcmd\r\n\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\n## ensure Linux binary is executable\r\nif [ -f /mnt/server/ConanSandbox/Binaries/Linux/ConanSandboxServer-Linux-Shipping ]; then\r\n\tchmod +x /mnt/server/ConanSandbox/Binaries/Linux/ConanSandboxServer-Linux-Shipping\r\nfi\r\n\r\n## seed directories and config files\r\nmkdir -p /mnt/server/ConanSandbox/Saved/Config/LinuxServer\r\nmkdir -p /mnt/server/ConanSandbox/Mods\r\n\r\n## seed ServerSettings.ini with the password (blank = no password)\r\nSS_INI=\"/mnt/server/ConanSandbox/Saved/Config/LinuxServer/ServerSettings.ini\"\r\nif [ ! -f \"${SS_INI}\" ]; then\r\n\t{\r\n\t\techo \"[ServerSettings]\"\r\n\t\techo \"ServerName=${SRV_NAME}\"\r\n\t\techo \"ServerPassword=${SRV_PW}\"\r\n\t\techo \"MaxPlayers=${MAX_PLAYERS:-40}\"\r\n\t} > \"${SS_INI}\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io/parkervcp/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
             "name": "App id",
-            "description": "The ID corresponding to the game to download.",
+            "description": "The Steam App ID for the dedicated server. Do not change.",
             "env_variable": "SRCDS_APPID",
             "default_value": "443030",
             "user_viewable": false,
@@ -41,8 +41,18 @@
             "field_type": "text"
         },
         {
+            "name": "Workshop App id",
+            "description": "The Steam App ID for workshop content. Do not change.",
+            "env_variable": "WORKSHOP_APPID",
+            "default_value": "440900",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:440900",
+            "field_type": "text"
+        },
+        {
             "name": "Auto Update",
-            "description": "Update server files on every boot. 1 = on, 0 = off. Adds 15-60s to startup.",
+            "description": "Decide if you want to update your server",
             "env_variable": "AUTO_UPDATE",
             "default_value": "1",
             "user_viewable": true,
@@ -102,7 +112,7 @@
         },
         {
             "name": "Mod List",
-            "description": "Comma separated Steam Workshop mod IDs",
+            "description": "Comma separated Steam Workshop mod IDs. Mods are downloaded and synced on every server boot.",
             "env_variable": "MOD_LIST",
             "default_value": "",
             "user_viewable": true,

--- a/conan_exiles/egg-conan-exiles-enhanced.json
+++ b/conan_exiles/egg-conan-exiles-enhanced.json
@@ -1,0 +1,114 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-05-13T17:35:54-04:00",
+    "name": "Conan Exiles Enhanced",
+    "author": "arrow816@gmail.com",
+    "description": "Conan Exiles Enhanced (UE5) dedicated server with Steam Workshop mod support. Native Linux server binary - no Wine required. Auto-updates game files on every boot when AUTO_UPDATE is 1.",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
+    },
+    "file_denylist": [],
+    "startup": ".\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping ConanSandbox -log -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -RconPort={{RCON_PORT}} -ServerName=\"{{SRV_NAME}}\" -MaxPlayers={{MAX_PLAYERS}}",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"Log file open\"\r\n}",
+        "logs": "{}",
+        "stop": "^^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# Conan Exiles Enhanced install script - native Linux\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n\techo -e \"steam user is not set.\\n\"\r\n\techo -e \"Using anonymous user.\\n\"\r\n\tSTEAM_USER=anonymous\r\n\tSTEAM_PASS=\"\"\r\n\tSTEAM_AUTH=\"\"\r\nelse\r\n\techo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps\r\ncd \/mnt\/server\/steamcmd\r\n\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## ensure Linux binary is executable\r\nif [ -f \/mnt\/server\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping ]; then\r\n\tchmod +x \/mnt\/server\/ConanSandbox\/Binaries\/Linux\/ConanSandboxServer-Linux-Shipping\r\nfi\r\n\r\n## seed directories and config files\r\nmkdir -p \/mnt\/server\/ConanSandbox\/Saved\/Config\/LinuxServer\r\nmkdir -p \/mnt\/server\/ConanSandbox\/Mods\r\n\r\n## seed ServerSettings.ini with the password (blank = no password)\r\nSS_INI=\"\/mnt\/server\/ConanSandbox\/Saved\/Config\/LinuxServer\/ServerSettings.ini\"\r\nif [ ! -f \"${SS_INI}\" ]; then\r\n\t{\r\n\t\techo \"[ServerSettings]\"\r\n\t\techo \"ServerName=${SRV_NAME}\"\r\n\t\techo \"ServerPassword=${SRV_PW}\"\r\n\t\techo \"MaxPlayers=${MAX_PLAYERS:-40}\"\r\n\t} > \"${SS_INI}\"\r\nfi\r\n\r\n## download workshop mods\r\nif [ -n \"${MOD_LIST}\" ]; then\r\n\techo \"Downloading workshop mods: ${MOD_LIST}\"\r\n\tIFS=',' read -ra MODS <<< \"${MOD_LIST}\"\r\n\tMOD_CMDS=\"\"\r\n\tfor id in \"${MODS[@]}\"; do\r\n\t\tid=$(echo \"${id}\" | tr -d '[:space:]')\r\n\t\tif [ -n \"${id}\" ]; then\r\n\t\t\tMOD_CMDS=\"${MOD_CMDS} +workshop_download_item 440900 ${id} validate\"\r\n\t\tfi\r\n\tdone\r\n\tif [ -n \"${MOD_CMDS}\" ]; then\r\n\t\t.\/steamcmd.sh +force_install_dir \/mnt\/server +login anonymous ${MOD_CMDS} +quit || echo \"Some mods failed.\"\r\n\tfi\r\n\t: > \/mnt\/server\/ConanSandbox\/Mods\/modlist.txt\r\n\tfor id in \"${MODS[@]}\"; do\r\n\t\tid=$(echo \"${id}\" | tr -d '[:space:]')\r\n\t\tif [ -n \"${id}\" ]; then\r\n\t\t\tSRC=\"\/mnt\/server\/steamapps\/workshop\/content\/440900\/${id}\"\r\n\t\t\tif [ -d \"${SRC}\" ]; then\r\n\t\t\t\tfor pak in \"${SRC}\"\/*.pak; do\r\n\t\t\t\t\tif [ -f \"${pak}\" ]; then\r\n\t\t\t\t\t\tNAME=$(basename \"${pak}\")\r\n\t\t\t\t\t\tcp -fv \"${pak}\" \"\/mnt\/server\/ConanSandbox\/Mods\/${NAME}\"\r\n\t\t\t\t\t\techo \"*${NAME}\" >> \/mnt\/server\/ConanSandbox\/Mods\/modlist.txt\r\n\t\t\t\t\tfi\r\n\t\t\t\tdone\r\n\t\t\tfi\r\n\t\tfi\r\n\tdone\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "App id",
+            "description": "The ID corresponding to the game to download.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "443030",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:443030",
+            "field_type": "text"
+        },
+        {
+            "name": "Auto Update",
+            "description": "Update server files on every boot. 1 = on, 0 = off. Adds 15-60s to startup.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Query Port",
+            "description": "Server Query Port",
+            "env_variable": "QUERY_PORT",
+            "default_value": "27015",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|numeric|max:65535",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Name",
+            "description": "",
+            "env_variable": "SRV_NAME",
+            "default_value": "Conan Exiles Enhanced Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:40",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Password",
+            "description": "Leave blank for no password.",
+            "env_variable": "SRV_PW",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Rcon port",
+            "description": "Remote administrative access",
+            "env_variable": "RCON_PORT",
+            "default_value": "25575",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|numeric",
+            "field_type": "text"
+        },
+        {
+            "name": "Max Players",
+            "description": "Maximum simultaneous players (1-100).",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "40",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|between:1,100",
+            "field_type": "text"
+        },
+        {
+            "name": "Mod List",
+            "description": "Comma separated Steam Workshop mod IDs",
+            "env_variable": "MOD_LIST",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a second egg `egg-conan-exiles-enhanced.json` alongside the original Conan Exiles egg, for Conan Exiles Enhanced — the May 5, 2026 Unreal Engine 5 rebuild of Conan Exiles. Updates `conan_exiles/README.md` and the root `README.md` to document both options.

Conan Exiles Enhanced shipped with a native Linux dedicated server binary at `ConanSandbox/Binaries/Linux/ConanSandboxServer-Linux-Shipping`, which eliminates the Wine + xvfb + vcrun2022 stack the original egg requires (see #544). This new egg uses `ghcr.io/parkervcp/steamcmd:debian` directly with no Wine layer.

Both eggs share App ID `443030`. The original egg remains useful for users specifically wanting the UE4 build via the `conan-exiles-legacy` Steam beta branch.

Related: #544

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: N/A — PR is from the `conan-exiles-enhanced` branch.

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [x] Does your egg use a custom docker image?
    * [x] Have you tried to use a generic image? — Uses `ghcr.io/parkervcp/steamcmd:debian`, the standard SteamCMD yolk.
    * [ ] Did you PR the necessary changes to make it work? — N/A, no yolk changes required.
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order? — Documented in `conan_exiles/README.md` alongside the original.
5. [x] You verify that the start command applied does not use a shell script
    * [x] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel

## Tested on
- Pterodactyl Panel 1.11.11
- Wings on native Linux
- Anonymous SteamCMD login for both the game and Workshop downloads
- Server appears in the in-game server browser
- Mods load correctly when listed in `MOD_LIST`