### PR TITLE
Add Team Fortress 2 egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Below is a categorized list of games with links to their respective server confi
 
 #### [Sunkenland](./sunkenland)
 
+#### [Team Fortress 2](./team_fortress_2)
+
 #### [Voyager of Nera](./voyagers_of_nera)
 
 #### [Windrose](./windrose)

--- a/team_fortress_2/README.md
+++ b/team_fortress_2/README.md
@@ -1,0 +1,29 @@
+# Team Fortress 2
+
+## From their [Website](https://www.teamfortress.com/)
+
+Team Fortress 2 is a team-based multiplayer first-person shooter developed by Valve. Players choose from nine character classes across game modes like Capture the Flag, Control Point, Payload, and King of the Hill.
+
+## Recommended Server Settings
+
+| RAM | CPU | Storage |
+|-----|-----|---------|
+| 2-4 GB | 2 Cores | 20 GB |
+
+## Server Ports
+
+TF2 needs 3 ports: a Primary Allocation for the game/RCON port, plus 2 Additional Allocations for the Client and SourceTV ports (set those two variables to match).
+
+| Port | Default | Allocation |
+|------|---------|------------|
+| **Game/RCON** | **27015** | Primary |
+| **Client** | **27005** | Additional |
+| SourceTV | 27020 | Additional |
+
+## GSLT
+
+Public servers need a free Game Server Login Token from <https://steamcommunity.com/dev/managegameservers> (pick "Team Fortress 2"), set as the GSLT variable. Without one the server still runs, it just won't show up in the server browser.
+
+## Steam Store Page
+
+https://store.steampowered.com/app/440/Team_Fortress_2/

--- a/team_fortress_2/egg-team-fortress-2.json
+++ b/team_fortress_2/egg-team-fortress-2.json
@@ -1,0 +1,144 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-07-02T02:37:00+10:00",
+    "name": "Team Fortress 2",
+    "author": "mark@bytesizelabs.com.au",
+    "description": "Team Fortress 2 is a team-based multiplayer first-person shooter developed by Valve. Players join one of two teams and choose from nine character classes, each with distinct weapons and abilities, across game modes such as Capture the Flag, Control Point, Payload, and King of the Hill.",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io\/ptero-eggs\/games:source": "ghcr.io\/ptero-eggs\/games:source"
+    },
+    "file_denylist": [],
+    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -strictportbind -ip 0.0.0.0 -port {{SERVER_PORT}} +clientport {{SRCDS_CPORT}} +tv_port {{SRCDS_STV}} +map {{SRCDS_MAP}} +servercfgfile server.cfg -maxplayers {{MAX_PLAYERS}} +sv_setsteamaccount {{STEAM_GSLT}}",
+    "config": {
+        "files": "{\r\n    \"tf\/cfg\/server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname\": \"hostname \\\"{{env.HOSTNAME}}\\\"\",\r\n            \"sv_password\": \"sv_password \\\"{{env.SERVER_PASSWORD}}\\\"\",\r\n            \"rcon_password\": \"rcon_password \\\"{{env.RCON_PASSWORD}}\\\"\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"gameserver Steam ID\"\r\n}",
+        "logs": "{}",
+        "stop": "quit"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/ptero-eggs\/installers:debian'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id found here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List\r\n# SRCDS_BETAID - beta branch of a steam app. Leave blank to install normal branch\r\n# SRCDS_BETAPASS - password for a beta branch should one be required during private or closed testing phases.. Leave blank for no password.\r\n# INSTALL_FLAGS - Any additional SteamCMD  flags to pass during install.. Keep in mind that steamcmd auto update process in the docker image might overwrite or ignore these when it performs update on server boot.\r\n# AUTO_UPDATE - Adding this variable to the egg allows disabling or enabling automated updates on boot. Boolean value. 0 to disable and 1 to enable.\r\n#\r\n ##\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## add below your custom commands if needed\r\n\r\n## seed server.cfg so hostname\/passwords can be written in on every boot\r\nmkdir -p \/mnt\/server\/tf\/cfg\r\nif [ ! -f \/mnt\/server\/tf\/cfg\/server.cfg ]; then\r\ncat <<EOF > \/mnt\/server\/tf\/cfg\/server.cfg\r\nhostname \"A Pterodactyl Hosted TF2 Server\"\r\nsv_password \"\"\r\nrcon_password \"\"\r\nEOF\r\nfi\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/ptero-eggs\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Server Name",
+            "description": "The name your server will show up as in the in-game server browser.",
+            "env_variable": "HOSTNAME",
+            "default_value": "A Pterodactyl Hosted TF2 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "field_type": "text"
+        },
+        {
+            "name": "Default Map",
+            "description": "The map your server loads on startup. Popular choices: ctf_2fort, cp_dustbowl, pl_badwater, koth_harvest_event.",
+            "env_variable": "SRCDS_MAP",
+            "default_value": "ctf_2fort",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:25",
+            "field_type": "text"
+        },
+        {
+            "name": "Max Players",
+            "description": "The maximum number of players allowed to join your server at once.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "24",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|max:128",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Password",
+            "description": "If set, players must enter this password to join your server. Leave blank to let anyone join.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:32",
+            "field_type": "text"
+        },
+        {
+            "name": "Admin (RCON) Password",
+            "description": "Password used by remote admin tools to manage your server (change maps, kick players, etc). Leave blank to disable remote admin access.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:32",
+            "field_type": "text"
+        },
+        {
+            "name": "Game Server Login Token (GSLT)",
+            "description": "A free token from Valve that makes your server show up in the public server browser. Get one at https:\/\/steamcommunity.com\/dev\/managegameservers (choose \"Team Fortress 2\"). Leave blank to run a private server that only people you directly invite can join.",
+            "env_variable": "STEAM_GSLT",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:32",
+            "field_type": "text"
+        },
+        {
+            "name": "Client Port",
+            "description": "A second network port the game uses alongside the main server port. Additional Allocation required - set this to match a secondary port you've allocated to this server.",
+            "env_variable": "SRCDS_CPORT",
+            "default_value": "27005",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1025,65535",
+            "field_type": "text"
+        },
+        {
+            "name": "SourceTV Port",
+            "description": "The port used for SourceTV, a feature that lets people spectate or record matches on your server. Additional Allocation required - set this to match a secondary port you've allocated to this server.",
+            "env_variable": "SRCDS_STV",
+            "default_value": "27020",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1025,65535",
+            "field_type": "text"
+        },
+        {
+            "name": "Auto Update",
+            "description": "Automatically update the server to the latest version every time it restarts.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Game ID",
+            "description": "Internal Steam identifier used to download and update the server. Do not change.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "232250",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:232250",
+            "field_type": "text"
+        },
+        {
+            "name": "Game Folder",
+            "description": "Internal folder name the server software runs from. Do not change.",
+            "env_variable": "SRCDS_GAME",
+            "default_value": "tf",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds an egg for Team Fortress 2 (App ID 232250) - the current, actively-updated Valve game. Not to be confused with the existing "Team Fortress 2 Classic" egg, which is a separate fan-made total conversion recreating the 2008-era TF2; this egg is for the live, still-supported TF2.

Standard SRCDS setup modeled on the existing Black Mesa / Left 4 Dead 2 eggs (`ghcr.io/ptero-eggs/games:source` yolk, steamcmd install). Exposes map, max players, server name, server/RCON passwords, GSLT, and client/SourceTV ports (additional allocations). Server name and passwords are written into `server.cfg` (same pattern as the Sven Co-op egg) instead of passed on the command line, since quoted command-line values get mangled by shell word-splitting once they contain spaces.

Tested against a live Pterodactyl instance: installs cleanly, starts, and is connectable with no errors.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
* [x] You verify that the start command applied does not use a shell script
* [x] The egg was exported from the panel

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [x] Have you tried to use a generic image? (yes - uses the stock `ghcr.io/ptero-eggs/games:source` yolk, no custom image needed)
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
6. [x] The egg was exported from the panel