### PR TITLE
Plutonium T6 & T5 eggs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Below is a categorized list of games with links to their respective server confi
 
 #### Call of Duty / COD 
 * [IW4X](./cod/iw4x)
+* [Plutonium T5](./cod/plutonium_t5)
+* [Plutonium T6](./cod/plutonium_t6)
 
 #### [Colony Survival](./colony_survival)
 

--- a/cod/plutonium_t5/README.md
+++ b/cod/plutonium_t5/README.md
@@ -1,0 +1,100 @@
+# Plutonium T5
+
+Plutonium is a community modification for Call of Duty: Black Ops that provides dedicated server support, modding, and an enhanced multiplayer experience.
+
+See https://plutonium.pw/docs/server/t5/setting-up-a-server/
+
+## Server Ports
+
+Plutonium T5 requires 1 port.
+
+| Port | Default |
+|------|---------|
+| Game | 28961   |
+
+This can be changed to any available port. The port must be allocated in the Pterodactyl panel and forwarded as **UDP**.
+
+## Prerequisites
+
+> [!IMPORTANT]
+>
+> Before installing, you need to obtain a legitimate copy of [Call of Duty: Black Ops on Steam](https://store.steampowered.com/app/42700/Call_of_Duty_Black_Ops/).
+>
+> - Game files are downloaded via SteamCMD using the App ID for your selected mode:
+>   - **Multiplayer (t5mp)**: `42710`
+>   - **Zombies (t5sp)**: `42700`
+> - Set **Game Mode** before installing — the installer downloads the matching component.
+> - To switch modes later, change **Game Mode** / **Config File** and **reinstall** the server.
+> - Your Steam account credentials must be set in the egg variables. Anonymous login is **not** supported.
+
+> [!CAUTION]
+> Only Steam is supported. The game must be owned on the Steam account used for installation.
+
+### Server key
+
+Create a server key at https://platform.plutonium.pw/serverkeys and set it in the **Server Key** egg variable.
+
+## Install Notes
+
+- Minimum **2 GB RAM** and **15 GB storage** recommended
+- Game files are downloaded via SteamCMD using your Steam credentials (Windows depot for Wine)
+- Plutonium client files are downloaded automatically during installation via [plutonium-updater](https://github.com/mxve/plutonium-updater.rs)
+- The server runs under Wine using 1st-party `ghcr.io/ptero-eggs/yolks:wine_*` images
+- Enable **Auto Update** to keep Plutonium client files current on each server start
+- Reinstall the server to re-download or validate game files from Steam
+
+### File layout
+
+After installation:
+
+```
+game/                              # Steam game files
+plutonium/                         # Plutonium client (from plutonium-updater)
+plutonium/storage/t5/
+├── dedicated.cfg                  # Multiplayer config (created if missing)
+└── dedicated_sp.cfg               # Zombies config (created if missing)
+```
+
+## Game Modes
+
+| Mode        | GAME_MODE | CONFIG_FILE      |
+|-------------|-----------|------------------|
+| Multiplayer | `t5mp`    | `dedicated.cfg`  |
+| Zombies     | `t5sp`    | `dedicated_sp.cfg` |
+
+When switching modes, update **Game Mode**, **Config File**, and **Max Clients** (Zombies typically uses 1–4 players), then reinstall if game files for the other mode are needed.
+
+## Settings
+
+Server settings are configured in `plutonium/storage/t5/dedicated.cfg` (Multiplayer) or `plutonium/storage/t5/dedicated_sp.cfg` (Zombies).
+
+The **Server Name** egg variable automatically updates `sv_hostname` in both config files on server start.
+
+Common settings to edit in your config file:
+
+- `rcon_password` — required for RCON and admin tools like IW4MAdmin
+- `g_password` — optional server join password (Multiplayer)
+- `sv_maxclients` / **Max Clients** variable — player limit
+- `sv_maprotation` — map and gametype rotation
+- `playlist_enabled 0` — required for custom map rotations (Multiplayer)
+
+See the [Plutonium T5 server documentation](https://plutonium.pw/docs/server/t5/setting-up-a-server/) and [T5ServerConfig](https://github.com/xerxes-at/T5ServerConfig) for advanced configuration examples.
+
+## Mods and Custom Maps
+
+| Type    | Location                         |
+|---------|----------------------------------|
+| Mods    | `plutonium/storage/t5/mods/`     |
+| Scripts | `plutonium/storage/t5/scripts/`  |
+| Logs    | written under `logs/` per config |
+
+Set the **Mod Directory** variable (e.g. `mods/my_mod`) to load a mod via `fs_game`.
+
+## Troubleshooting
+
+- **Steam install fails**: Verify the account owns Black Ops and credentials are correct. If 2FA is enabled, set **Steam Auth** with your login code.
+- **Server not in browser**: Confirm the UDP port is open and forwarded. It can take several minutes to appear in the server list after first start.
+- **Wine display errors**: These are harmless; the dedicated server runs as a console application.
+- **binkw32.dll errors**: Reinstall the server to re-download game files, or verify the `game/` directory contains a complete Steam install.
+- **Map rotation ignored**: Set `playlist_enabled 0` in your Multiplayer config.
+- **Startup detection**: If the panel stays on "Starting", check console output and adjust the `done` detection string if needed.

--- a/cod/plutonium_t5/egg-plutonium-t5.json
+++ b/cod/plutonium_t5/egg-plutonium-t5.json
@@ -1,0 +1,185 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-07-16T23:59:34+01:00",
+    "name": "Plutonium T5",
+    "author": "poitor@vxl.to",
+    "description": "Plutonium is a community modification for Call of Duty: Black Ops that provides dedicated server support, modding, and an enhanced multiplayer experience. This egg supports both Multiplayer (t5mp) and Zombies (t5sp) game modes. Requires a Steam account that owns Black Ops to download game files.",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "Wine-Latest": "ghcr.io\/ptero-eggs\/yolks:wine_latest",
+        "Wine-Staging": "ghcr.io\/ptero-eggs\/yolks:wine_staging"
+    },
+    "file_denylist": [],
+    "startup": "if [ \"${AUTO_UPDATE}\" == \"1\" ]; then .\/plutonium-updater -d plutonium; fi && cd plutonium && wine .\/bin\/plutonium-bootstrapper-win32.exe {{GAME_MODE}} \"Z:\\\\home\\\\container\\\\game\" -dedicated +set key {{SERVER_KEY}} +set fs_game {{MOD}} +exec {{CONFIG_FILE}} +set net_port {{SERVER_PORT}} +set sv_maxclients {{MAX_CLIENTS}} +map_rotate",
+    "config": {
+        "files": "{\r\n    \"plutonium\/storage\/t5\/dedicated.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"set sv_hostname\": \"set sv_hostname \\\"{{server.build.env.SERVER_NAME}}\\\"\"\r\n        }\r\n    },\r\n    \"plutonium\/storage\/t5\/dedicated_sp.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"set sv_hostname\": \"set sv_hostname \\\"{{server.build.env.SERVER_NAME}}\\\"\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Sending heartbeat to master\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# Plutonium T5 Installation Script\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd (Windows files for Wine)\r\nmkdir -p \/mnt\/server\/game\r\ninstall_steam_app() {\r\n    echo \"Installing Steam App ID ${1}...\"\r\n    .\/steamcmd.sh +force_install_dir \/mnt\/server\/game +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${1} validate +quit\r\n}\r\n\r\nif [ \"${GAME_MODE}\" == \"t5sp\" ]; then\r\n    install_steam_app ${T5SP_APPID}\r\nelse\r\n    install_steam_app ${T5MP_APPID}\r\nfi\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## Download plutonium-updater and Plutonium client files\r\ncd \/mnt\/server\r\ncurl -sSL -o plutonium-updater.tar.gz https:\/\/github.com\/mxve\/plutonium-updater.rs\/releases\/latest\/download\/plutonium-updater-x86_64-unknown-linux-gnu.tar.gz\r\ntar -xzf plutonium-updater.tar.gz\r\nchmod +x plutonium-updater\r\nrm -f plutonium-updater.tar.gz\r\n.\/plutonium-updater -d plutonium\r\n\r\n## Create default server configs if not present\r\nmkdir -p plutonium\/storage\/t5\r\n\r\nif [ ! -f plutonium\/storage\/t5\/dedicated.cfg ]; then\r\ncat > plutonium\/storage\/t5\/dedicated.cfg << 'DEDICFG'\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\/\/ Plutonium T5 MP - Basic Server\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\r\nset sv_hostname \"Plutonium T5 Server\"\r\nset g_password \"\"\r\nset rcon_password \"CHANGE_ME_RCON\"\r\nset sv_maxclients 18\r\nset sv_voice 1\r\nset g_logSync 1\r\nset g_log \"logs\/games_mp.log\"\r\nset playlist_enabled 0\r\n\r\nset sv_maprotation \"gametype tdm map mp_crash map mp_nuked map mp_firingrange map mp_cairo\"\r\nDEDICFG\r\nfi\r\n\r\nif [ ! -f plutonium\/storage\/t5\/dedicated_sp.cfg ]; then\r\ncat > plutonium\/storage\/t5\/dedicated_sp.cfg << 'SPCFG'\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\/\/ Plutonium T5 SP - Basic Server\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\r\nset sv_hostname \"Plutonium T5 Server\"\r\nset rcon_password \"CHANGE_ME_RCON\"\r\nset sp_minplayers 1\r\nset g_logSync 1\r\nset g_log \"logs\/games_sp.log\"\r\n\r\nset sv_maprotation \"map zombie_theater map zombie_pentagon map zombie_cosmodrome\"\r\nSPCFG\r\nfi\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"\r\n",
+            "container": "ghcr.io\/ptero-eggs\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Steam User",
+            "description": "This is a required setting and cannot be set to anonymous.",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Password",
+            "description": "Steam account password.",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Multiplayer App ID",
+            "description": "Steam App ID for Call of Duty: Black Ops Multiplayer (t5mp).",
+            "env_variable": "T5MP_APPID",
+            "default_value": "42710",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Zombies App ID",
+            "description": "Steam App ID for Call of Duty: Black Ops (t5sp).",
+            "env_variable": "T5SP_APPID",
+            "default_value": "42700",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Auth",
+            "description": "Steam account auth code. Required if you have 2FA enabled.",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:5",
+            "field_type": "text"
+        },
+        {
+            "name": "Windows Install",
+            "description": "",
+            "env_variable": "WINDOWS_INSTALL",
+            "default_value": "1",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Key",
+            "description": "Your Plutonium server key from https:\/\/platform.plutonium.pw\/serverkeys",
+            "env_variable": "SERVER_KEY",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "field_type": "text"
+        },
+        {
+            "name": "Game Mode",
+            "description": "Game mode to run. Use t5mp for Multiplayer or t5sp for Zombies.",
+            "env_variable": "GAME_MODE",
+            "default_value": "t5mp",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:t5mp,t5sp",
+            "field_type": "text"
+        },
+        {
+            "name": "Config File",
+            "description": "Server configuration file to execute. Use dedicated.cfg for Multiplayer or dedicated_sp.cfg for Zombies.",
+            "env_variable": "CONFIG_FILE",
+            "default_value": "dedicated.cfg",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:dedicated.cfg,dedicated_sp.cfg",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Name",
+            "description": "Sets the server hostname displayed in the server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Plutonium T5 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "Max Clients",
+            "description": "Maximum players allowed on the server (1-32 for MP, 1-4 recommended for Zombies).",
+            "env_variable": "MAX_CLIENTS",
+            "default_value": "18",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1,32",
+            "field_type": "text"
+        },
+        {
+            "name": "Mod Directory",
+            "description": "Optional mod directory path passed to fs_game (e.g. mods\/my_mod). Leave empty for no mod.",
+            "env_variable": "MOD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "Auto Update",
+            "description": "Automatically update Plutonium client files on server start using plutonium-updater.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Winetricks",
+            "description": "",
+            "env_variable": "WINETRICKS_RUN",
+            "default_value": "vcrun2022",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        },
+        {
+            "name": "Wine Debug",
+            "description": "",
+            "env_variable": "WINEDEBUG",
+            "default_value": "-all",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        }
+    ]
+}

--- a/cod/plutonium_t6/README.md
+++ b/cod/plutonium_t6/README.md
@@ -1,0 +1,103 @@
+# Plutonium T6
+
+Plutonium is a community modification for Call of Duty: Black Ops II that provides dedicated server support, modding, and an enhanced multiplayer experience.
+
+See https://plutonium.pw/docs/server/t6/setting-up-a-server/
+
+## Server Ports
+
+Plutonium T6 requires 1 port.
+
+| Port | Default |
+|------|---------|
+| Game | 4976    |
+
+This can be changed to any available port. The port must be allocated in the Pterodactyl panel and forwarded as **UDP**.
+
+## Prerequisites
+
+> [!IMPORTANT]
+>
+> Before installing, you need to obtain a legitimate copy of [Call of Duty: Black Ops II on Steam](https://store.steampowered.com/app/202970/Call_of_Duty_Black_Ops_II/).
+>
+> - Game files are downloaded via SteamCMD using the App ID for your selected mode:
+>   - **Multiplayer (t6mp)**: `202990`
+>   - **Zombies (t6zm)**: `212910`
+> - Set **Game Mode** before installing — the installer downloads the matching component.
+> - To switch modes later, change **Game Mode** / **Config File** and **reinstall** the server.
+> - Your Steam account credentials must be set in the egg variables. Anonymous login is **not** supported.
+
+> [!CAUTION]
+> Only Steam is supported. The game must be owned on the Steam account used for installation.
+
+### Server key
+
+Create a server key at https://platform.plutonium.pw/serverkeys and set it in the **Server Key** egg variable.
+
+## Install Notes
+
+- Minimum **2 GB RAM** and **20 GB storage** recommended
+- Game files are downloaded via SteamCMD using your Steam credentials (Windows depot for Wine)
+- Plutonium client files are downloaded automatically during installation via [plutonium-updater](https://github.com/mxve/plutonium-updater.rs)
+- The server runs under Wine using 1st-party `ghcr.io/ptero-eggs/yolks:wine_*` images
+- Enable **Auto Update** to keep Plutonium client files current on each server start
+- Reinstall the server to re-download or validate game files from Steam
+
+### Game file layout
+
+After installation, game files are located in `game/`:
+
+```
+game/
+├── main/
+│   ├── dedicated.cfg      (created by installer if missing)
+│   └── dedicated_zm.cfg   (created by installer if missing)
+├── zone/
+└── ...
+```
+
+Plutonium client files are installed to `plutonium/`.
+
+## Game Modes
+
+| Mode   | GAME_MODE | CONFIG_FILE      |
+|--------|-----------|------------------|
+| Multiplayer | `t6mp` | `dedicated.cfg`  |
+| Zombies     | `t6zm` | `dedicated_zm.cfg` |
+
+When switching modes, update both the **Game Mode** and **Config File** variables to match.
+
+## Settings
+
+Server settings are configured in `game/main/dedicated.cfg` (Multiplayer) or `game/main/dedicated_zm.cfg` (Zombies).
+
+The **Server Name** egg variable automatically updates `sv_hostname` in both config files on server start.
+
+Common settings to edit in your config file:
+
+- `rcon_password` — required for RCON and admin tools like IW4MAdmin
+- `g_password` — optional server join password
+- `sv_maxclients` — player limit (1–18)
+- `sv_maprotation` — map and gametype rotation
+
+See the [Plutonium T6 server documentation](https://plutonium.pw/docs/server/t6/setting-up-a-server/) for map rotation syntax and gametype configuration.
+
+## Mods and Custom Maps
+
+| Type         | Location                              |
+|--------------|---------------------------------------|
+| Mods         | `plutonium/storage/t6/mods/`          |
+| MP maps      | `game/usermaps/`                      |
+| ZM maps      | `game/usermaps/`                      |
+| Logs         | `plutonium/storage/t6/logs/`          |
+| Stats        | `plutonium/storage/t6/stats/`         |
+
+Set the **Mod Directory** variable (e.g. `mods/my_mod`) to load a mod via `fs_game`.
+
+## Troubleshooting
+
+- **Steam install fails**: Verify the account owns Black Ops II and credentials are correct. If 2FA is enabled, set **Steam Auth** with your login code.
+- **Server not in browser**: Confirm the UDP port is open and forwarded. It can take several minutes to appear in the server list after first start.
+- **Wine display errors**: These are harmless; the dedicated server runs as a console application.
+- **binkw32.dll errors**: Reinstall the server to re-download game files, or verify the `game/` directory contains a complete Steam install.
+- **Startup detection**: If the panel stays on "Starting", the `done` detection string may need adjustment after checking console output for the heartbeat message.

--- a/cod/plutonium_t6/egg-plutonium-t6.json
+++ b/cod/plutonium_t6/egg-plutonium-t6.json
@@ -1,0 +1,175 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-07-16T23:59:36+01:00",
+    "name": "Plutonium T6",
+    "author": "poitor@vxl.to",
+    "description": "Plutonium is a community modification for Call of Duty: Black Ops II that provides dedicated server support, modding, and an enhanced multiplayer experience. This egg supports both Multiplayer (t6mp) and Zombies (t6zm) game modes. Requires a Steam account that owns Black Ops II to download game files.",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "Wine-Latest": "ghcr.io\/ptero-eggs\/yolks:wine_latest",
+        "Wine-Staging": "ghcr.io\/ptero-eggs\/yolks:wine_staging"
+    },
+    "file_denylist": [],
+    "startup": "if [ \"${AUTO_UPDATE}\" == \"1\" ]; then .\/plutonium-updater -d plutonium; fi && cd plutonium && wine .\/bin\/plutonium-bootstrapper-win32.exe {{GAME_MODE}} \"Z:\\\\home\\\\container\\\\game\" -dedicated +set key {{SERVER_KEY}} +set fs_game {{MOD}} +set net_port {{SERVER_PORT}} +exec {{CONFIG_FILE}} +map_rotate",
+    "config": {
+        "files": "{\r\n    \"game\/main\/dedicated.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"set sv_hostname\": \"set sv_hostname \\\"{{server.build.env.SERVER_NAME}}\\\"\"\r\n        }\r\n    },\r\n    \"game\/main\/dedicated_zm.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"set sv_hostname\": \"set sv_hostname \\\"{{server.build.env.SERVER_NAME}}\\\"\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Sending heartbeat to master\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# Plutonium T6 Installation Script\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd (Windows files for Wine)\r\nmkdir -p \/mnt\/server\/game\r\ninstall_steam_app() {\r\n    echo \"Installing Steam App ID ${1}...\"\r\n    .\/steamcmd.sh +force_install_dir \/mnt\/server\/game +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${1} validate +quit\r\n}\r\n\r\nif [ \"${GAME_MODE}\" == \"t6zm\" ]; then\r\n    install_steam_app ${T6ZM_APPID}\r\nelse\r\n    install_steam_app ${T6MP_APPID}\r\nfi\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## Download plutonium-updater and Plutonium client files\r\ncd \/mnt\/server\r\ncurl -sSL -o plutonium-updater.tar.gz https:\/\/github.com\/mxve\/plutonium-updater.rs\/releases\/latest\/download\/plutonium-updater-x86_64-unknown-linux-gnu.tar.gz\r\ntar -xzf plutonium-updater.tar.gz\r\nchmod +x plutonium-updater\r\nrm -f plutonium-updater.tar.gz\r\n.\/plutonium-updater -d plutonium\r\n\r\n## Create default server configs if not present\r\nmkdir -p game\/main\r\n\r\nif [ ! -f game\/main\/dedicated.cfg ]; then\r\ncat > game\/main\/dedicated.cfg << 'DEDICFG'\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\/\/ Plutonium T6 MP - Basic Server\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\r\nset sv_hostname \"Plutonium T6 Server\"\r\nset sv_motd \"Powered by Pterodactyl\"\r\n\r\nset rcon_password \"CHANGE_ME_RCON\"\r\nset g_password \"\"\r\n\r\nset sv_maxclients 18\r\nset sv_voice 1\r\n\r\nset g_log \"logs\/games_mp.log\"\r\nset g_logSync 2\r\n\r\nsv_maprotation \"execgts tdm.cfg map mp_raid map mp_hijacked map mp_village map mp_express\"\r\nDEDICFG\r\nfi\r\n\r\nif [ ! -f game\/main\/dedicated_zm.cfg ]; then\r\ncat > game\/main\/dedicated_zm.cfg << 'ZMDEDICFG'\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\/\/ Plutonium T6 ZM - Basic Server\r\n\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\r\n\r\nset sv_hostname \"Plutonium T6 Server\"\r\nset rcon_password \"CHANGE_ME_RCON\"\r\n\r\nset g_log \"logs\/games_zm.log\"\r\nset g_logSync 2\r\n\r\nsv_maprotation \"execgts zm_classic_transit.cfg map zm_transit\"\r\nZMDEDICFG\r\nfi\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"\r\n",
+            "container": "ghcr.io\/ptero-eggs\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Server Key",
+            "description": "Your Plutonium server key from https:\/\/platform.plutonium.pw\/serverkeys",
+            "env_variable": "SERVER_KEY",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "field_type": "text"
+        },
+        {
+            "name": "Game Mode",
+            "description": "Game mode to run. Use t6mp for Multiplayer or t6zm for Zombies.",
+            "env_variable": "GAME_MODE",
+            "default_value": "t6mp",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:t6mp,t6zm",
+            "field_type": "text"
+        },
+        {
+            "name": "Config File",
+            "description": "Server configuration file to execute. Use dedicated.cfg for Multiplayer or dedicated_zm.cfg for Zombies.",
+            "env_variable": "CONFIG_FILE",
+            "default_value": "dedicated.cfg",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:dedicated.cfg,dedicated_zm.cfg",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Name",
+            "description": "Sets the server hostname displayed in the server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Plutonium T6 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "Mod Directory",
+            "description": "Optional mod directory path passed to fs_game (e.g. mods\/my_mod). Leave empty for no mod.",
+            "env_variable": "MOD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:100",
+            "field_type": "text"
+        },
+        {
+            "name": "Auto Update",
+            "description": "Automatically update Plutonium client files on server start using plutonium-updater.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Winetricks",
+            "description": "",
+            "env_variable": "WINETRICKS_RUN",
+            "default_value": "vcrun2022",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        },
+        {
+            "name": "Wine Debug",
+            "description": "",
+            "env_variable": "WINEDEBUG",
+            "default_value": "-all",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam User",
+            "description": "This is a required setting and cannot be set to anonymous.",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Password",
+            "description": "Steam account password.",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Auth",
+            "description": "Steam account auth code. Required if you have 2FA enabled.",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:5",
+            "field_type": "text"
+        },
+        {
+            "name": "Windows Install",
+            "description": "",
+            "env_variable": "WINDOWS_INSTALL",
+            "default_value": "1",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
+        },
+        {
+            "name": "Multiplayer App ID",
+            "description": "Steam App ID for Call of Duty: Black Ops II Multiplayer (t6mp).",
+            "env_variable": "T6MP_APPID",
+            "default_value": "202990",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Zombies App ID",
+            "description": "Steam App ID for Call of Duty: Black Ops II Zombies (t6zm).",
+            "env_variable": "T6ZM_APPID",
+            "default_value": "212910",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "string",
+            "field_type": "text"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

This adds support for Plutonium T6 and T5 MP and ZM for both games under the cod folder. Both eggs utilize SteamCMD for download the gamefiles. 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel