### PR TITLE
Add native Linux Windrose egg

### DIFF
--- a/windrose/README.md
+++ b/windrose/README.md
@@ -1,9 +1,16 @@
 # Windrose
 Embark on a PvE survival adventure in the Age of Piracy. Fight on land and sea, solo or with friends. Build, craft and explore vast open world filled with dark secrets. Master soulslite combat and take on challenging bosses, command your ship and plunder unspoken treasures!
 
+## Available eggs
+- `egg-windrose.json` installs the Windows dedicated server through SteamCMD and runs it with Wine.
+- `egg-windrose-linux.json` runs the native Linux server payload distributed through the publisher's Docker image using `ghcr.io/pterodactyl/games:windrose`.
+
+The Linux egg stores only persistent server data in the Pterodactyl volume. Application updates are delivered through rebuilt container images and do not require a Pterodactyl reinstall.
+
 ## Warning
 - If running in a VM, set the CPU type to host/passthrough (or equivalent) to expose full CPU features and avoid crashes such as:
 Unhandled illegal instruction at address 000000014147C7F8 (thread 0154), starting debugger...
+- The Linux runtime is currently available for `linux/amd64` only because the publisher image does not provide an arm64 payload.
 
 ## Server Requirements
 | Players | RAM  | Storage |
@@ -14,10 +21,27 @@ Unhandled illegal instruction at address 000000014147C7F8 (thread 0154), startin
 
 # Connecting to the server
 Players can connect by:
-- Using the Direct Connect feature, allowing you to connect to the server using your servers allocated ip:port
-- Using the Invite Code set by the Invite Code variable (and password if set) the Invite Code does not work when Direct Connect is enabled.
-- The Invite Code can be found in /home/container/R5/ServerDescription.json and changed in your Invite Code variable.
+- Using the Direct Connect feature, allowing connection through the server's allocated hostname or IP and port. The allocation must be reachable through both TCP and UDP.
+- Using Invite Code/P2P mode with the effective invite code and password, if configured. The invite code is not used while Direct Connect is enabled.
+
+For the Linux egg, Invite Code and World Island ID may be left empty. Windrose will generate or preserve them in `R5/ServerDescription.json`. The runtime also prints the effective values and writes them to `R5/GeneratedServerValues.txt`.
 
 ## Server Ports
-- With the Invite Code, ports are dynamically assigned via NAT punch-through. Ensure your router supports UPnP. Disable proxy/VPN temporarily if connections fail.
-- With Direct Connect it will use your servers allocated Game Port instead.
+- With the Invite Code, ports are dynamically assigned through NAT punch-through. Ensure the router supports UPnP. Disable proxy/VPN temporarily if connections fail.
+- With Direct Connect, the allocated game port is used and must be reachable through both TCP and UDP.
+
+## Persistent files for the Linux egg
+The relevant persistent data is:
+
+```text
+R5/Saved/
+R5/ServerDescription.json
+R5/GeneratedServerValues.txt
+```
+
+For migration or disaster recovery, restore at least `R5/Saved/` and `R5/ServerDescription.json` before starting the replacement server.
+
+## Updates and backups
+The Linux application payload is included in the runtime image. A newly published image is applied when Wings recreates the server container; the saved world and server configuration remain in the server volume.
+
+Create a backup before applying a new Windrose version because game updates may migrate save data. Windrose's internal backup path is redirected into the persistent server volume.

--- a/windrose/egg-windrose-linux.json
+++ b/windrose/egg-windrose-linux.json
@@ -1,0 +1,122 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-07-30T19:54:41+02:00",
+    "name": "Windrose - Linux",
+    "author": "1725073+Kalanur@users.noreply.github.com",
+    "description": "Runs the official native Linux Windrose dedicated server from an automatically rebuilt runtime image. Saves and ServerDescription.json remain in the Pterodactyl volume while application updates are delivered by pulling a new container image.",
+    "features": [],
+    "docker_images": {
+        "ghcr.io\/pterodactyl\/games:windrose": "ghcr.io\/pterodactyl\/games:windrose"
+    },
+    "file_denylist": [],
+    "startup": "\/usr\/local\/bin\/windrose-start",
+    "config": {
+        "files": "{}",
+        "startup": "{\n    \"done\": \"Bringing up level for play took\"\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\nset -euo pipefail\n\nreadonly TARGET_DIRECTORY=\"\/mnt\/server\"\n\nmkdir -p \\\n    \"${TARGET_DIRECTORY}\/R5\/Saved\/.windrose-var-tmp\" \\\n    \"${TARGET_DIRECTORY}\/R5\"\n\nif [[ -f \"${TARGET_DIRECTORY}\/R5\/Binaries\/Linux\/WindroseServer-Linux-Shipping\" ]]; then\n    echo \"Legacy Windrose application files were detected in the server volume.\"\n    echo \"They are ignored because the current runtime image contains the application payload.\"\n    echo \"Remove them only after verifying the new image and keeping a backup.\"\nfi\n\ncat <<'MESSAGE'\nWindrose persistent storage initialized.\nThe official native server payload is included in the runtime image and is updated by pulling a newly built image.\nR5\/Saved and R5\/ServerDescription.json remain in the Pterodactyl server volume.\nMESSAGE\n",
+            "container": "ghcr.io\/pterodactyl\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Server Name",
+            "description": "Name shown for this Windrose server.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Pterodactyl Windrose Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:40",
+            "field_type": "text"
+        },
+        {
+            "name": "Invite Code",
+            "description": "Leave empty to let Windrose generate or preserve the invite code. A non-empty value is an explicit override. The effective value is printed at startup and written to R5\/GeneratedServerValues.txt.",
+            "env_variable": "INVITE_CODE",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|min:6|max:32|regex:\/^[a-zA-Z0-9]+$\/",
+            "field_type": "text"
+        },
+        {
+            "name": "Server Password",
+            "description": "Leave empty to disable password protection.",
+            "env_variable": "PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:30",
+            "field_type": "text"
+        },
+        {
+            "name": "Maximum Players",
+            "description": "Maximum number of simultaneous players.",
+            "env_variable": "MAX_PLAYER_COUNT",
+            "default_value": "8",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|min:1|max:10",
+            "field_type": "text"
+        },
+        {
+            "name": "Connection Region",
+            "description": "Connection Service region. EU also covers North America. Leave empty for automatic selection.",
+            "env_variable": "USER_SELECTED_REGION",
+            "default_value": "EU",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|in:EU,SEA,CIS",
+            "field_type": "text"
+        },
+        {
+            "name": "P2P Proxy Address",
+            "description": "Listening address for invite-code\/P2P mode. For same-LAN clients this may need the host LAN address.",
+            "env_variable": "P2P_PROXY_ADDRESS",
+            "default_value": "127.0.0.1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|ip",
+            "field_type": "text"
+        },
+        {
+            "name": "Use Direct Connection",
+            "description": "Use the primary Pterodactyl allocation directly. The same port must be reachable through TCP and UDP.",
+            "env_variable": "USE_DIRECT_CONNECTION",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "World Island ID",
+            "description": "Leave empty for a new world or to preserve the current world. Set an existing world folder ID when importing a save. The effective value is printed at startup and written to R5\/GeneratedServerValues.txt.",
+            "env_variable": "WORLD_ISLAND_ID",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:64|regex:\/^[A-Za-z0-9_-]+$\/",
+            "field_type": "text"
+        },
+        {
+            "name": "Automatic Corrupt-Save Recovery",
+            "description": "Automatically load the latest backup when the active save is detected as broken.",
+            "env_variable": "AUTO_LOAD_LATEST_BACKUP_IF_HAS_BROKEN",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a second Windrose egg for the publisher-provided native Linux dedicated
server while keeping the existing SteamCMD/Wine egg unchanged.

The Linux egg:

- uses `ghcr.io/pterodactyl/games:windrose`;
- stores `R5/Saved` and `R5/ServerDescription.json` persistently in the
  Pterodactyl server volume;
- supports both Invite Code/P2P and Direct Connect modes;
- preserves generated Invite Code and World Island ID values when the
  corresponding variables are left empty;
- documents migration, recovery, image-based updates and the amd64-only
  runtime requirement.

## Dependency

This pull request depends on pterodactyl/yolks#79.

The referenced image `ghcr.io/pterodactyl/games:windrose` will not be available
until that pull request is accepted and the image has been published.

The current egg candidate has been exported from the Pterodactyl Panel with the
target image reference. This PR remains a draft until:

- pterodactyl/yolks#79 is merged;
- `ghcr.io/pterodactyl/games:windrose` is published;
- the exported egg has been installed and tested against the published image.

## Testing performed

The same runtime and egg logic, using a private image namespace, has been tested
with:

- fresh installation and new-world creation;
- existing-world import;
- Invite Code/P2P connection;
- Direct Connect through a public hostname and port;
- persistent saves and configuration across stop/start and runtime-image
  updates;
- periodic backups and shutdown backup;
- disaster recovery by restoring `R5/Saved/` and
  `R5/ServerDescription.json`.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you tested and reviewed your changes with confidence that everything works?
  * The same implementation has been fully tested using a private image
    namespace. Final testing against `ghcr.io/pterodactyl/games:windrose` is
    pending publication of the image.
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * Branch: `add-windrose-linux-egg`

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
    * The startup helper is included in pterodactyl/yolks#79 and is not editable
      from the server volume.
* [x] The egg was exported from the panel
  * Exported from the Pterodactyl Panel on 2026-07-30 using the target runtime
    and installer image references.

## New egg Submissions

1. [ ] Does your submission pass tests (server is connectable)?
   * The same implementation is connectable through both Invite Code/P2P and
     Direct Connect when using the tested private image. Final testing against
     the official image is pending.
2. [x] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
      * A generic runtime image cannot provide the native Windrose server
        payload because the publisher distributes that payload through its
        Docker image rather than as a separately downloadable Linux package.
    * [x] Did you PR the necessary changes to make it work?
      * pterodactyl/yolks#79
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg according to the alphabetical order?
   * Windrose already exists in the main repository index. The existing
     `windrose/README.md` has been extended to document both available eggs.
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
   * Not applicable: this is a second egg in the existing `windrose` directory.
     The existing `windrose/README.md` has been extended to document both the
     SteamCMD/Wine egg and the native Linux egg.
5. [ ] You verify that the start command applied does not use a shell script
    * [x] If some script is needed then it is part of a current yolk or a PR to add one
      * The required startup helper is part of pterodactyl/yolks#79.
6. [x] The egg was exported from the panel
   * Exported from the Pterodactyl Panel on 2026-07-30 using the target runtime
     and installer image references.